### PR TITLE
fix header block height in mobile version

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -181,6 +181,10 @@ header nav .nav-tools {
 }
 
 @media (max-width: 991px) {
+  header .block {
+    padding: 0;
+  }
+
   header .navbar-header {
     position: relative;
     padding: 20px 15px;
@@ -188,6 +192,10 @@ header nav .nav-tools {
     margin: 0;
     margin-right: -15px;
     margin-left: -15px;
+  }
+
+  #header-logo {
+    height: auto;
   }
 
   header #header-logo img {


### PR DESCRIPTION
To test this, inspect header .block and see that Before it overlaps with content and After it doesn't
This was preventing usability of breadcrumb

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/newsroom/news/blueshift-announces-assay-development-collaboration-active-motif
- After: https://header-mobile-height-fix--moleculardevices--hlxsites.hlx.live/newsroom/news/blueshift-announces-assay-development-collaboration-active-motif
