### PR TITLE
feat: implement embed block for soundcloud player

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,11 @@
+main .embed {
+  width: unset;
+  text-align: center;
+  max-width: 800px;
+  margin: 32px auto;
+}
+
+main .embed > div {
+  display: flex;
+  justify-content: center;
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,55 @@
+const getDefaultEmbed = (url) => {
+  const embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+      <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
+        scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+      </iframe>
+    </div>`;
+
+  return embedHTML;
+};
+
+const embedSoundcloud = (url) => {
+  const embedHTML = `<div style="left: 0; width: 100%; height: 166px; position: relative;">
+        <iframe src="${url.href}" 
+        style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
+        frameborder="0" loading="lazy"></iframe>
+      </div>`;
+  return embedHTML;
+};
+
+const loadEmbed = (block, link, autoplay) => {
+  if (block.classList.contains('embed-is-loaded')) {
+    return;
+  }
+
+  const EMBEDS_CONFIG = [
+    {
+      match: ['soundcloud'],
+      embed: embedSoundcloud,
+    },
+  ];
+
+  const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
+  const url = new URL(link);
+  if (config) {
+    block.innerHTML = config.embed(url, autoplay);
+    block.classList = `block embed embed-${config.match[0]}`;
+  } else {
+    block.innerHTML = getDefaultEmbed(url);
+    block.classList = 'block embed';
+  }
+  block.classList.add('embed-is-loaded');
+};
+
+export default function decorate(block) {
+  const link = block.querySelector('a').href;
+  block.textContent = '';
+
+  const observer = new IntersectionObserver((entries) => {
+    if (entries.some((e) => e.isIntersecting)) {
+      observer.disconnect();
+      loadEmbed(block, link);
+    }
+  });
+  observer.observe(block);
+}

--- a/test/blocks/embed/block.html
+++ b/test/blocks/embed/block.html
@@ -1,0 +1,16 @@
+<div class="embed-wrapper">
+  <div
+    class="block embed embed-soundcloud embed-is-loaded"
+    data-block-name="embed"
+    data-block-status="loaded"
+  >
+    <div style="left: 0; width: 100%; height: 166px; position: relative">
+      <iframe
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1248631222&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true"
+        style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute"
+        frameborder="0"
+        loading="lazy"
+      ></iframe>
+    </div>
+  </div>
+</div>

--- a/test/blocks/embed/embed.test.js
+++ b/test/blocks/embed/embed.test.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-unused-expressions */
+/* global describe it */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const sleep = async (time = 1000) => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(true);
+  }, time);
+});
+
+describe('Embed block for Sound cloud', () => {
+  // eslint-disable-next-line no-undef
+  before(async () => {
+    const { decorateBlock, loadBlock } = await import('../../../scripts/lib-franklin.js');
+    document.body.innerHTML = await readFile({ path: './block.html' });
+    const embedBlock = document.querySelector('div.embed-wrapper .embed');
+    await decorateBlock(embedBlock);
+    await loadBlock(embedBlock);
+    await sleep();
+  });
+
+  it('Tests test iframe configuration', async () => {
+    const container = document.querySelector('div.embed-wrapper .embed-soundcloud');
+    expect(container).to.exist;
+
+    const wrapper = container.querySelector('div');
+    expect(wrapper).to.exist;
+    expect(wrapper.style.height).to.equal('166px');
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe).to.exist;
+    expect(iframe.src).to.contain('soundcloud');
+  });
+});


### PR DESCRIPTION
Implement Soundcloud player embed. LHS is impacted by the heavy soundcloud player, not much we can do about it. The player is already loaded if visible only.

Fix #141

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
- After: https://embed-soundcloud--moleculardevices--hlxsites.hlx.page/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
- Test: https://embed-soundcloud--moleculardevices--hlxsites.hlx.live/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality