### PR TITLE
143 - [Footer] All footer social icons have wrong links & not title

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -30,6 +30,12 @@ function buildNewsEvents(container) {
   addEventListeners(container);
 }
 
+function decorateSocialMediaLinks(socialIconsContainer) {
+  socialIconsContainer.querySelectorAll('a').forEach((iconLink) => {
+    iconLink.ariaLabel = `molecular devices ${iconLink.children[0].classList[1].split('-')[2]} page`;
+  });
+}
+
 /**
  * loads and decorates the footer
  * @param {Element} block The header block element
@@ -58,6 +64,10 @@ export default async function decorate(block) {
       footerWrap.appendChild(row);
     } else {
       footerBottom.appendChild(row);
+    }
+
+    if (i === 4) {
+      decorateSocialMediaLinks(row);
     }
   });
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #143

Link contents was fixed in the word document.

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://143-footer-icons--moleculardevices--hlxsites.hlx.page/
