### PR TITLE
index h1 for breadcrumbs title

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -54,6 +54,9 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      breadcrumbsTitle:
+        select: h1
+        value: textContent(el)
   fragments:
     include:
       - '/fragments/**'

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -54,7 +54,7 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
-      breadcrumbsTitle:
+      h1:
         select: h1
         value: textContent(el)
   fragments:


### PR DESCRIPTION
Breadcrumbs title is using the H1 value hence it needs to be indexed to be retrieved for current page and ancestor pages at:
https://github.com/hlxsites/moleculardevices/blob/27950d2c8ce413166ae269d7415c1a8e0f41612f/blocks/breadcrumbs/breadcrumbs-create.js#L31