### PR TITLE
fix: adapt new content parsing in products related applications

### DIFF
--- a/blocks/related-applications/related-applications.js
+++ b/blocks/related-applications/related-applications.js
@@ -39,8 +39,8 @@ export default async function decorate(block) {
     if (fragmentHtml) {
       const fragmentElement = document.createElement('div');
       fragmentElement.innerHTML = fragmentHtml;
-      const h1 = fragmentElement.querySelector('h1');
-      return { id: h1.id, title: h1.textContent, html: fragmentElement };
+      const h3 = fragmentElement.querySelector('h3');
+      return { id: h3.id, title: h3.textContent, html: fragmentElement };
     }
     return null;
   }));


### PR DESCRIPTION
Fix #190

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager#applications
- After: https://190-related-apps-newcontent--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager#applications
