### PR TITLE
fix - Hero Image Resolution too low on Mobile

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -1,4 +1,4 @@
-import { getMetadata } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
 import { formatDate } from '../../scripts/scripts.js';
 import createBreadcrumbs from '../breadcrumbs/breadcrumbs-create.js';
 import { getVideoId, buildVideo } from '../vidyard/video-create.js';
@@ -70,8 +70,21 @@ export default async function decorate(block) {
   block.appendChild(breadcrumbs);
   block.appendChild(container);
 
-  const picture = block.querySelector('picture');
+  let picture = block.querySelector('picture');
   if (picture) {
+    const originalHeroBg = picture.lastElementChild;
+    const optimizedHeroBg = createOptimizedPicture(
+      originalHeroBg.src,
+      originalHeroBg.getAttribute('alt'),
+      true,
+      [
+        { media: '(min-width: 600px)', width: '2000' },
+        { width: '1200' }
+      ],
+    );
+
+    picture.replaceWith(optimizedHeroBg);
+    picture = optimizedHeroBg;
     picture.classList.add('hero-background');
     block.prepend(picture.parentElement);
   }

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -79,7 +79,7 @@ export default async function decorate(block) {
       true,
       [
         { media: '(min-width: 600px)', width: '2000' },
-        { width: '1200' }
+        { width: '1200' },
       ],
     );
 


### PR DESCRIPTION
Fix for customer feedback:

> In mobile version.
> * Main banner looking fade as compare to original

This might have some small negative impact on #198, but I don't think it is avoidable as the image does look too low res on mobile devices.

Original: https://moleculardevices.com/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
- After: https://hero-img-resolution--moleculardevices--hlxsites.hlx.live/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
