### PR TITLE
fix - Recent Blogs Carousel Next/Prev Buttons too small

### DIFF
--- a/blocks/recent-blogs-carousel/recent-blogs-carousel.css
+++ b/blocks/recent-blogs-carousel/recent-blogs-carousel.css
@@ -155,11 +155,11 @@ main .carousel.recent-blogs-carousel .blog-carousel-caption .button.primary {
   }
 
   main .carousel-wrapper.recent-blogs-carousel-wrapper  .carousel-nav-left {
-    left: -10px;
+    left: 0px;
   }
 
   main .carousel-wrapper.recent-blogs-carousel-wrapper  .carousel-nav-right {
-    right: -10px;
+    right: 0px;
   }
 
   main .carousel.recent-blogs-carousel {
@@ -180,5 +180,10 @@ main .carousel.recent-blogs-carousel .blog-carousel-caption .button.primary {
 
   main .carousel.recent-blogs-carousel .carousel-item {
     width: 100%;
+  }
+
+  main .carousel-wrapper.recent-blogs-carousel-wrapper .carousel-nav-button .icon {
+    height: 38px;
+    width: 38px;
   }
 }

--- a/blocks/recent-blogs-carousel/recent-blogs-carousel.css
+++ b/blocks/recent-blogs-carousel/recent-blogs-carousel.css
@@ -155,11 +155,11 @@ main .carousel.recent-blogs-carousel .blog-carousel-caption .button.primary {
   }
 
   main .carousel-wrapper.recent-blogs-carousel-wrapper  .carousel-nav-left {
-    left: 0px;
+    left: 0;
   }
 
   main .carousel-wrapper.recent-blogs-carousel-wrapper  .carousel-nav-right {
-    right: 0px;
+    right: 0;
   }
 
   main .carousel.recent-blogs-carousel {


### PR DESCRIPTION
Fix customer feedback:

> In mobile version.
> * Recent posts carrousel next/prev icons are smaller than original

![icon-size-new](https://user-images.githubusercontent.com/42608830/232393311-561a017f-096d-4855-bf6a-681efc7674ef.png)
![icon-size-orig](https://user-images.githubusercontent.com/42608830/232393349-e6396147-389c-4491-968d-e0212cd1218e.png)

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
- After: https://blog-carousel-btns--moleculardevices--hlxsites.hlx.live/lab-notes/clone-screening/challenges-of-cell-line-development-and-emerging-technologies-to-regulate-monoclonality
