### PR TITLE
fix: white space on product pages mobile view

### DIFF
--- a/blocks/page-tabs/page-tabs.css
+++ b/blocks/page-tabs/page-tabs.css
@@ -12,6 +12,8 @@ main .page-tabs {
   padding: 0 15px;
   height: 60px;
   white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 main .page-tabs ul {


### PR DESCRIPTION
Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://pages-tabs-overflow--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
