### PR TITLE
Add mobile menu items and search

### DIFF
--- a/blocks/header/header-events.js
+++ b/blocks/header/header-events.js
@@ -76,7 +76,13 @@ function addEventListenersDesktop() {
   addListeners('.search-form', 'submit', (e) => {
     e.preventDefault();
     e.stopPropagation();
-    submitSearchForm(e);
+    submitSearchForm(e, 'searchQuery');
+  });
+
+  addListeners('.mobile-menu .search-form', 'submit', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    submitSearchForm(e, 'mobileSearchQuery');
   });
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -117,6 +117,11 @@ header .actionable-card-submenu li {
   margin-bottom: 10px;
 }
 
+header .mobile-menu li {
+  float: none;
+  position: relative;
+}
+
 header .text-submenu > div {
   display: flex;
   flex-wrap: wrap;
@@ -237,6 +242,34 @@ header .nav-tabs .menu-nav-submenu-section {
 
 header .nav-tabs .menu-nav-submenu-section:hover {
   background-color: rgba(255 255 255 / 30%);
+}
+
+header .mobile-menu .company-links li {
+  border-bottom: 1px solid #f1f2f3;
+  float: none;
+  border-top: 0;
+  text-align: center;
+  text-transform: capitalize;
+  font-size: 17px !important;
+  color: #6a747c;
+  width: 35%;
+  margin-top: 15px;
+}
+
+
+header .mobile-menu li h1,
+header .mobile-menu li h2 {
+  font-size: 18px;
+  color: #34393d;
+  font-family: 'Proxima Nova Light', sans-serif;
+  font-weight: 300;
+  text-shadow: none;
+}
+
+header .mobile-menu .company-links li picture {
+  display: block;
+  margin: 0 auto;
+  margin-bottom: 15px;
 }
 
 header .company-links > ul > li:last-child {
@@ -373,6 +406,237 @@ header .cards-submenu img {
   height: auto;
 }
 
+/* Mobile Menu */
+header .mobile-menu {
+  position: fixed;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  height: calc(100% - 63px);
+  top: 63px;
+  overflow: hidden;
+  display: none;
+}
+
+header .mobile-menu > ul {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  float: left;
+  list-style-type: none;
+  padding-inline-start: 0;
+}
+
+header .mobile-menu .headersearch {
+  position: static;
+  background: #f0f1f2;
+  padding: 25px 15px;
+  height: auto;
+  display: block;
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+header .mobile-menu .search {
+  padding-right: 30px;
+  position: relative;
+}
+
+header .mobile-menu .search > form {
+  border: 0;
+  border-bottom: 1px solid #6a747c;
+  margin: 0;
+  padding: 0;
+}
+
+header .form-control:focus {
+  outline: none;
+}
+
+header .mobile-menu .form-control {
+  border-bottom: 0;
+  height: 25px;
+  font-size: 17px;
+  margin-left: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+  color: #34393d;
+  background: none;
+  font-family: 'Proxima Nova Regular', sans-serif;
+  width: 100%;
+}
+
+header .mobile-menu .searchbutton {
+  bottom: -15px;
+  width: 25px;
+  min-width: 10px;
+  font-size: 25px;
+  color: #34393d;
+  background: none;
+  border: 0;
+  outline: 0;
+  position: absolute;
+  line-height: inherit;
+  font-family: inherit;
+}
+
+header .mobile-menu-item {
+  border-bottom: 1px solid #f1f2f3;
+  float: none;
+  border-top: 0;
+  position: relative;
+  font-size: 18px;
+  color: #34393d;
+  font-family: 'Proxima Nova Light', sans-serif;
+  font-weight: 300;
+  text-shadow: none;
+}
+
+header .mobile-menu li a {
+  position: relative;
+  white-space: nowrap;
+  display: block;
+  padding: 18px 70px 19px 15px;
+  text-align: left;
+  text-transform: uppercase;
+  margin-bottom: 0;
+  line-height: 20px;
+  color: #34393d;
+  text-decoration: none;
+}
+
+header .mobile-menu-subcategories {
+  display: none;
+}
+
+header .mobile-menu .caret {
+  padding: 18px 50px 18px 15px;
+  position: absolute;
+  top: 0;
+  right: 20px;
+  bottom: 0;
+  height: 100%;
+  width: 45px;
+  border: 0;
+  cursor: pointer;
+  z-index: 1;
+  margin-left: 2px;
+  vertical-align: middle;
+}
+
+header .mobile-menu .caret::before {
+  content: "\f105";
+  font-size: 25px !important;
+  text-align: center;
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  right: 15px;
+  border-radius: 100%;
+  border: 1px solid #c4ccda;
+  color: #34393d;
+  top: 50%;
+  display: inline-block;
+  font-family: FontAwesome, sans-serif;
+  margin-top: -15px;
+}
+
+header .menu-nav-submenu h1 > a {
+  color: inherit;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+header .cards-submenu ul li a {
+  color: var(--text-white);
+  font-family: 'Proxima Nova Regular', sans-serif;
+  font-weight: 300;
+  line-height: 15px;
+  padding: 1px 5px;
+  display: block;
+  text-transform: none;
+}
+
+header .text-submenu ul > li > a {
+  font-size: 11px;
+  color: #fff;
+  border-bottom: 0;
+  line-height: 15px;
+  padding-left: 0;
+  padding-top: 0;
+  padding-bottom: 8px;
+  font-weight: 300;
+  display: block;
+  text-transform: none;
+}
+
+header .mobile-menu .request-quote a {
+  line-height: 20px;
+  background: #f8a100;
+  font-size: 18px;
+  padding: 18px 50px 18px 15px;
+  text-shadow: none;
+  color: #fff;
+  font-family: 'Proxima Nova Regular', sans-serif;
+  text-align: center;
+  display: block;
+  text-transform: inherit;
+}
+
+header .mobile-menu .company-links {
+  background: #f0f1f2;
+  padding: 4px 15px 10px;
+  position: relative;
+  top: auto;
+  right: auto;
+}
+
+header .cards-submenu ul {
+  padding: 0;
+  margin: 0;
+  margin-top: 10px;
+}
+
+header .large-card-submenu ul {
+  padding: 0;
+  width: 45%;
+  position: relative;
+  min-height: 1px;
+  padding-left: 20px;
+  margin-bottom: 40px;
+  font-family: Quicksand, sans-serif;
+  font-weight: 200;
+  font-size: 14px;
+  text-align: left;
+  list-style-type: disc;
+}
+
+header .mobile-menu .company-links ul {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-left: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+header .mobile-menu .company-links li a {
+  padding: 0 0 11px;
+  line-height: 1.4286;
+  text-transform: inherit;
+  text-align: inherit;
+}
+
+header .mobile-menu .company-links li:nth-child(2) {
+  padding: 0 0 11px;
+  line-height: 1.4286;
+  text-transform: inherit;
+}
+
+/* Mobile Menu - END */
+
 header .col-1 {
   flex-basis: calc(100% - 10px);
   box-sizing: border-box;
@@ -395,28 +659,6 @@ header .col-4 > div > div {
   flex-basis: calc(25% - 10px);
   box-sizing: border-box;
   max-width: 100%;
-}
-
-header .cards-submenu ul {
-  padding: 0;
-  margin: 0;
-  margin-top: 10px;
-}
-
-header .menu-nav-submenu h1 > a {
-  color: inherit;
-  text-decoration: none;
-  text-transform: uppercase;
-}
-
-header .cards-submenu ul li a {
-  color: var(--text-white);
-  font-family: 'Proxima Nova Regular', sans-serif;
-  font-weight: 300;
-  line-height: 15px;
-  padding: 1px 5px;
-  display: block;
-  text-transform: none;
 }
 
 header .nav-tabs .menu-nav-submenu > div {
@@ -442,19 +684,6 @@ header .nav-tabs .menu-nav-submenu h1 {
 header .nav-tabs .menu-nav-submenu h1:hover {
   background-color: rgba(255 255 255 / 30%);
   cursor: pointer;
-}
-
-header .text-submenu ul > li > a {
-  font-size: 11px;
-  color: #fff;
-  border-bottom: 0;
-  line-height: 15px;
-  padding-left: 0;
-  padding-top: 0;
-  padding-bottom: 8px;
-  font-weight: 300;
-  display: block;
-  text-transform: none;
 }
 
 header .actionable-card-submenu > div:nth-child(2) {
@@ -505,20 +734,6 @@ header .nav-tabs .menu-nav-submenu-head {
   position: relative;
   padding-top: 20px;
   width: 50%;
-}
-
-header .large-card-submenu ul {
-  padding: 0;
-  width: 45%;
-  position: relative;
-  min-height: 1px;
-  padding-left: 20px;
-  margin-bottom: 40px;
-  font-family: Quicksand, sans-serif;
-  font-weight: 200;
-  font-size: 14px;
-  text-align: left;
-  list-style-type: disc;
 }
 
 header .nav-tabs .menu-nav-submenu ul {
@@ -831,6 +1046,10 @@ header .actionable-card-submenu > div:nth-child(2) > div:nth-child(2) img {
     display: initial;
   }
 
+  header .mobile-menu.mobile-menu-open {
+    display: initial;
+  }
+
   header #header-logo {
     height: auto;
   }
@@ -1034,10 +1253,6 @@ header .actionable-card-submenu > div:nth-child(2) > div:nth-child(2) img {
     border: 1px solid #ccc;
     border-radius: 4px;
     color: #555;
-  }
-
-  header .header-search .form-control:focus {
-    outline: none;
   }
 
   header .header-search form button {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -120,6 +120,7 @@ header .actionable-card-submenu li {
 header .mobile-menu li {
   float: none;
   position: relative;
+  color: #34393d;
 }
 
 header .text-submenu > div {
@@ -270,6 +271,11 @@ header .mobile-menu .company-links li picture {
   display: block;
   margin: 0 auto;
   margin-bottom: 15px;
+}
+
+header .mobile-menu li:hover {
+  color: var(--link-color);
+  background: #f0f1f2;
 }
 
 header .company-links > ul > li:last-child {
@@ -503,7 +509,7 @@ header .mobile-menu li a {
   text-transform: uppercase;
   margin-bottom: 0;
   line-height: 20px;
-  color: #34393d;
+  color: inherit;
   text-decoration: none;
 }
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,15 +1,7 @@
 import handleViewportChanges from './header-events.js';
-import { getMetadata, decorateIcons, toClassName } from '../../scripts/lib-franklin.js';
-import { buildHamburger } from './menus/mobile-menu.js';
-import buildSearch from './menus/search.js';
-
-function buildBrandLogo(content) {
-  const logoWrapper = document.createElement('div');
-  logoWrapper.setAttribute('id', 'header-logo');
-  const logoImg = content.querySelector('.nav-brand > div > div > picture');
-  logoWrapper.innerHTML = logoImg.outerHTML;
-  return logoWrapper;
-}
+import { buildHamburger, buildMobileMenu } from './menus/mobile-menu.js';
+import { buildBrandLogo, fetchHeaderContent } from './helpers.js';
+import { buildNavbar } from './header-megamenu.js';
 
 function buildTools(content) {
   const toolsList = content.querySelector('div:nth-child(2)');
@@ -17,25 +9,6 @@ function buildTools(content) {
   toolsWrapper.classList = ('company-links');
   toolsWrapper.innerHTML = toolsList.innerHTML;
   return toolsWrapper;
-}
-
-function buildRequestQuote() {
-  const requestQuote = document.createElement('li');
-  requestQuote.classList.add('header-rfq');
-  requestQuote.innerHTML = '<a title="" href="/quote-request?cid=12" target="">Request<br>Quote</a>';
-  return requestQuote;
-}
-
-export async function fetchHeaderContent() {
-  const navPath = getMetadata('nav') || '/nav';
-  const resp = await fetch(`${navPath}.plain.html`, window.location.pathname.endsWith('/nav') ? { cache: 'reload' } : {});
-  if (!resp.ok) return {};
-
-  const html = await resp.text();
-
-  const content = document.createElement('div');
-  content.innerHTML = html;
-  return content;
 }
 
 /**
@@ -59,50 +32,10 @@ export default async function decorate(block) {
   headerWrapper.classList.add('container', 'sticky-element', 'sticky-mobile');
   headerWrapper.append(navbarHeader);
 
-  // ------ Nav ------
-  // Create wrapper for nav
-  const mainMenuWrapper = document.createElement('div');
-  mainMenuWrapper.classList.add('mainmenu-wrapper', 'sticky-element', 'sticky-desktop');
+  const megaMenu = buildNavbar(content);
+  const mobileMenu = buildMobileMenu();
 
-  const container = document.createElement('div');
-  container.classList.add('container');
-  const newNav = document.createElement('nav');
-  newNav.setAttribute('id', 'nav');
-
-  const navTabs = content.querySelector('.nav-menu');
-  newNav.innerHTML = navTabs.outerHTML;
-  container.append(buildBrandLogo(content));
-  container.append(newNav);
-  mainMenuWrapper.append(container);
-
-  // link section
-  const navMenuUl = document.createElement('ul');
-  navMenuUl.classList.add('nav-tabs');
-  const menus = [...mainMenuWrapper.querySelectorAll('.nav-menu > div')];
-
-  for (let i = 0; i < menus.length; i += 1) {
-    const item = document.createElement('li');
-    item.classList.add('menu-expandable');
-    item.setAttribute('aria-expanded', 'false');
-
-    const menuTitle = menus[i];
-    const textDiv = menuTitle.querySelector('div');
-    menuTitle.innerHTML = textDiv.innerHTML;
-    menuTitle.classList.add('menu-nav-category');
-    menuTitle.setAttribute('menu-id', toClassName(menuTitle.textContent));
-
-    item.innerHTML = menuTitle.outerHTML;
-    navMenuUl.append(item);
-  }
-
-  navMenuUl.append(buildSearch(content));
-  navMenuUl.append(buildRequestQuote());
-
-  mainMenuWrapper.querySelector('.nav-menu').innerHTML = navMenuUl.outerHTML;
-
-  decorateIcons(mainMenuWrapper);
-
-  block.append(headerWrapper, mainMenuWrapper);
+  block.append(headerWrapper, megaMenu, mobileMenu);
 
   handleViewportChanges(block);
 }

--- a/blocks/header/helpers.js
+++ b/blocks/header/helpers.js
@@ -1,0 +1,41 @@
+import { getMetadata } from '../../scripts/lib-franklin.js';
+import {
+  a,
+  div,
+} from '../../scripts/dom-helpers.js';
+
+export function buildBrandLogo(content) {
+  const logoWrapper = div({ id: 'header-logo' });
+  const logoImg = content.querySelector('.nav-brand > div > div > picture');
+  logoWrapper.innerHTML = logoImg.outerHTML;
+  return logoWrapper;
+}
+
+export async function fetchHeaderContent() {
+  const navPath = getMetadata('nav') || '/nav';
+  const resp = await fetch(`${navPath}.plain.html`, window.location.pathname.endsWith('/nav') ? { cache: 'reload' } : {});
+  if (!resp.ok) return {};
+
+  const html = await resp.text();
+
+  const content = document.createElement('div');
+  content.innerHTML = html;
+  return content;
+}
+
+export function reverseElementLinkTagRelation(element) {
+  const linkElement = element.querySelector('a');
+  if (linkElement) {
+    element.removeChild(linkElement);
+
+    const newLinkElement = a({ href: linkElement.href });
+
+    element.innerHTML = linkElement.innerHTML;
+    element.parentNode.replaceChild(newLinkElement, element);
+
+    newLinkElement.appendChild(element);
+    return newLinkElement;
+  }
+
+  return element;
+}

--- a/blocks/header/menus/mobile-menu.js
+++ b/blocks/header/menus/mobile-menu.js
@@ -1,49 +1,103 @@
+import { reverseElementLinkTagRelation } from '../helpers.js';
 import {
-  div,
-  form,
-  fieldset,
-  input,
   ul,
   li,
+  a,
   nav,
   span,
   button,
 } from '../../../scripts/dom-helpers.js';
+import { buildMobileSearch } from './search.js';
 
-// TODO: styling
-function buildSearchForm() {
-  return div(
-    { class: 'headersearch' },
-    div(
-      { class: 'search' },
-      form(
-        fieldset(
-          input(
-            {
-              class: 'form-control', id: 'search_keyword_search21', name: 'search', placeholder: 'Search moleculardevices.com', type: 'text',
-            },
-          ),
-          button(
-            { class: 'searchbutton', type: 'submit', 'aria-label': 'Search' },
-          ),
-        ),
-      ),
+// This function receives the content of one of the mobile menu items (eg. "Products", etc.)
+// and builds the <li> element for it.
+export function buildMobileMenuItem(itemContent, menuId) {
+  // get all the h2s in the itemContent
+  const menuItem = li({ class: 'mobile-menu-item' });
+
+  // create first menu item which when clicked will show the other subcategories
+  const titleLink = itemContent.querySelector('h1 a');
+  menuItem.append(titleLink, span({ class: 'caret' }));
+
+  const h2s = [...itemContent.querySelectorAll('h2')];
+  const subCategories = ul({ class: 'mobile-menu-subcategories', 'menu-id': menuId });
+
+  // add back to parent button
+  const backToParentMenuItem = li(
+    { class: 'back-to-parent' },
+    a(
+      { href: '#' },
+      titleLink.textContent,
     ),
   );
+  subCategories.append(backToParentMenuItem);
+
+  // add button to parent directly
+  const parentItem = li(
+    { class: 'mobile-menu-subcategory-item' },
+    titleLink.textContent,
+  );
+  subCategories.append(parentItem);
+
+  // add H2s to list
+  h2s.forEach((h2) => {
+    const element = reverseElementLinkTagRelation(h2);
+    element.append(span({ class: 'caret' }));
+
+    const h2ListItem = li(
+      { class: 'mobile-menu-subcategory-item' },
+      element,
+    );
+
+    subCategories.append(h2ListItem);
+  });
+
+  menuItem.append(subCategories);
+
+  const mobileMenuItems = document.querySelector('.mobile-menu-items');
+  mobileMenuItems.append(menuItem);
 }
 
-// TODO: add nav menu items
+export function buildMobileMenuTools(content) {
+  const mobileMenuItems = document.querySelector('.mobile-menu-items');
+
+  // create Contact Us button
+  const contactUsItem = li(
+    { class: 'mobile-menu-item contact-us' },
+    a(
+      { href: '/contact' },
+      'Contact Us',
+    ),
+  );
+  mobileMenuItems.append(contactUsItem);
+
+  // create Request Quote button
+  const requestQuoteItem = li(
+    { class: 'mobile-menu-item request-quote' },
+    a(
+      { href: '/quote-request' },
+      'Request Quote',
+    ),
+  );
+  mobileMenuItems.append(requestQuoteItem);
+
+  // create Tools buttons
+  const toolsList = content.querySelector('div:nth-child(2)');
+  const toolsWrapper = li(
+    { class: 'mobile-menu-item company-links' },
+    toolsList,
+  );
+  mobileMenuItems.append(toolsWrapper);
+}
+
 export function buildMobileMenu() {
   return nav(
     { class: 'mobile-menu' },
     ul(
-      { class: 'nav-menu' },
+      { class: 'mobile-menu-items' },
       li(
         { class: 'headersearch-item' },
-        buildSearchForm(),
-      ),
-      li(
-        { class: 'mobile-menu-item' },
+        buildMobileSearch(),
       ),
     ),
   );
@@ -69,14 +123,17 @@ export function buildHamburger() {
 
   // add listener to toggle hamburger
   hamburger.addEventListener('click', () => {
+    const mobileMenu = document.querySelector('.mobile-menu');
     if (hamburger.classList.contains('hamburger-open')) {
       // if hamburger is open, close it
       hamburger.classList.remove('hamburger-open');
       hamburger.classList.add('hamburger-close');
+      mobileMenu.classList.toggle('mobile-menu-open');
     } else {
       // if hamburger is closed, open it
       hamburger.classList.remove('hamburger-close');
       hamburger.classList.add('hamburger-open');
+      mobileMenu.classList.toggle('mobile-menu-open');
     }
   });
 

--- a/blocks/header/menus/search.js
+++ b/blocks/header/menus/search.js
@@ -5,14 +5,36 @@ import {
   form,
   input,
   button,
+  i,
 } from '../../../scripts/dom-helpers.js';
 
-export function submitSearchForm(event) {
+export function submitSearchForm(event, searchQueryId) {
   event.preventDefault();
-  const searchQuery = document.getElementById('searchQuery').value;
+  const searchQuery = document.getElementById(searchQueryId).value;
   const encodedQuery = encodeURIComponent(searchQuery);
   const searchUrl = `/search-results#q=${encodedQuery}&t=All&sort=relevancy`;
   window.location.href = searchUrl;
+}
+
+export function buildMobileSearch() {
+  return div(
+    { class: 'headersearch' },
+    div(
+      { class: 'search' },
+      form(
+        { class: 'search-form', action: '/search-results', method: 'GET' },
+        input(
+          {
+            id: 'mobileSearchQuery', class: 'form-control', placeholder: 'Search moleculardevices.com', type: 'text',
+          },
+        ),
+        button(
+          { class: 'searchbutton', type: 'submit', 'aria-label': 'Search' },
+          i({ class: 'fa fa-search' }),
+        ),
+      ),
+    ),
+  );
 }
 
 export default function buildSearch(content) {
@@ -27,7 +49,7 @@ export default function buildSearch(content) {
       },
     ),
     button(
-      { class: 'transparentBtn btn searchbutton', type: 'submit' },
+      { class: 'transparentBtn btn searchbutton', type: 'submit', 'aria-label': 'Search' },
       'Search',
     ),
   );


### PR DESCRIPTION
This PR adds the first mobile menu view that is seen after clicking the hamburger button.

Keep in mind that each of the subcategories doesn't work yet. Since this PR was becoming quite big I decided to split the changes.

## Changes

- Refactored some of the code so that it uses the dom-helpers
- Refactored some of the code so that the mobile menu's subcategories could be built along the desktop megamenu. This reduces the number of times we poll the content and iterate over it
- Added code to build the mobile menu list items and style it

## Notes

- The subcategories don't work yet, so clicking the arrows shouldn't do anything
- Submitting the search form results in the usage of the wrong parameters. Will be fixed in the next PR

## Look
![Screenshot 2023-04-27 at 15 18 52](https://user-images.githubusercontent.com/37300462/234874076-e13300a5-7822-406f-bcbd-9b67a983abae.png)


Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://add-mobile-menu-initial-screen--moleculardevices--hlxsites.hlx.page/
