### PR TITLE
fix: remove default h3 styles on product pages

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -827,16 +827,10 @@ main .section.wave .default-content-wrapper p:first-of-type {
   margin-bottom: 10px;
 }
 
-.product .section.tabs h2,
-.section.tabs h3  {
+.product .section.tabs h2 {
   font-size: 36px;
   font-family: var(--ff-proxima-regular);
   margin-top: 0;
-}
-
-.product .section.tabs h3 {
-  font-size: 24px;
-  font-family: var(--ff-proxima-xbold);
 }
 
 .product .section.tabs > div > h3 {


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://fix-product-h3--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
