### PR TITLE
fix: remove default paragraph font size in product pages

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -837,10 +837,6 @@ main .section.wave .default-content-wrapper p:first-of-type {
   margin: 45px 15px 15px;
 }
 
-.product .section.tabs[aria-labelledby=overview] h3 + p {
-  font-size: 18px;
-}
-
 main .section .default-content-wrapper h2:only-child {
   margin-top: 0;
   margin-bottom: 0;


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://product-p-font--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
