### PR TITLE
fix: fix breadcrumb loading

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -271,7 +271,6 @@ export async function decorateMain(main) {
   decorateBlocks(main);
   detectSidebar(main);
   decorateLinkedPictures(main);
-  createBreadcrumbsSpace(main);
   decorateEmbedLinks(main);
 }
 
@@ -285,6 +284,7 @@ async function loadEager(doc) {
   if (main) {
     await decorateTemplates(main);
     await decorateMain(main);
+    createBreadcrumbsSpace(main);
     await waitForLCP(LCP_BLOCKS);
   }
 }


### PR DESCRIPTION
Fix breadcrumb loading. `createBreadcrumbsSpace` should only be loaded for the main document, not for fragments

Fix #330

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers
- After: https://breadcrumb-fix--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers
