### PR TITLE
fix: latest resources only aligned center on product page

### DIFF
--- a/blocks/latest-resources/latest-resources.css
+++ b/blocks/latest-resources/latest-resources.css
@@ -1,6 +1,5 @@
-.latest-resources-container {
+.product .latest-resources-container {
   text-align: center;
-  padding-top: 90px;
 }
 
 main .carousel-wrapper.latest-resources-wrapper {


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://resources-align-center--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/applications/3d-cell-models/organoids/intestinal-organoids
- After: https://resources-align-center--moleculardevices--hlxsites.hlx.page/applications/3d-cell-models/organoids/intestinal-organoids
