### PR TITLE
chore: Index Subcategories

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -25,6 +25,9 @@ indices:
         select: head > meta[name="template"]
         value: attribute(el, "content")
       category:
+        select: head > meta[name="sub-category"]
+        value: attribute(el, "content")
+      subCategory:
         select: head > meta[name="category"]
         value: attribute(el, "content")
       technologyType:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -25,10 +25,10 @@ indices:
         select: head > meta[name="template"]
         value: attribute(el, "content")
       category:
-        select: head > meta[name="sub-category"]
+        select: head > meta[name="category"]
         value: attribute(el, "content")
       subCategory:
-        select: head > meta[name="category"]
+        select: head > meta[name="sub-category"]
         value: attribute(el, "content")
       technologyType:
         select: head > meta[name="technology-type"]


### PR DESCRIPTION
We need subcategories indexed for building https://www.moleculardevices.com/products/accessories-consumables. Where we look up all items that have the **subcategory** `Accessories and Consumables` and then we create filters based on the main category.

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://index-subcategories--moleculardevices--hlxsites.hlx.page/
