### PR TITLE
392 - [Products] Chevron icon to large for related products card

### DIFF
--- a/blocks/card-list/card-list.css
+++ b/blocks/card-list/card-list.css
@@ -50,20 +50,6 @@ main .card-list .carousel-item .card {
   box-shadow: 0 1px 10px rgba(0 0 0 / 20%);
 }
 
-main .card-list .carousel-item .card a .icon {
-  margin-left: 5px;
-  vertical-align: text-top;
-}
-
-main .card-list .carousel-item .card a .icon svg {
-  height: 18px;
-  width: 18px;
-}
-
-main .card-list .carousel-item .card a .icon svg path {
-  stroke-width: 15;
-}
-
 @media only screen and (max-width: 1200px) {
   main .section div.card-list-wrapper {
     width: 970px;

--- a/blocks/card/card.css
+++ b/blocks/card/card.css
@@ -95,6 +95,20 @@ main .card-type {
   display: none;
 }
 
+main .card a .icon.icon-chevron-right-outline {
+  margin-left: 5px;
+  vertical-align: text-top;
+}
+
+main .card a .icon.icon-chevron-right-outline svg {
+  height: 18px;
+  width: 18px;
+}
+
+main .card a .icon.icon-chevron-right-outline svg path {
+  stroke-width: 15;
+}
+
 @media only screen and (max-width: 767px) {
   main .card-thumb {
     height: 150px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #392 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/cellular-imaging-systems/acquisition-and-analysis-software/in-carta-image-analysis-software#related-products-services
- After: https://392-products-chevron--moleculardevices--hlxsites.hlx.live/products/cellular-imaging-systems/acquisition-and-analysis-software/in-carta-image-analysis-software#related-products-services
