### PR TITLE
feat: use gated URLs for cards and resources

### DIFF
--- a/blocks/card/card.js
+++ b/blocks/card/card.js
@@ -41,14 +41,15 @@ class Card {
     }
     const thumbnailBlock = this.imageBlockReady
       ? item.imageBlock : createOptimizedPicture(itemImage, item.title, 'lazy', [{ width: '800' }]);
-
+    const cardLink = (item.gated === 'Yes' && item.gatedURL && item.gatedURL !== '0')
+      ? item.gatedURL : item.path;
     const buttonText = item.cardC2A && item.cardC2A !== '0' ? item.cardC2A : this.defaultButtonText;
-    let c2aBlock = a({ href: item.path, 'aria-label': buttonText, class: 'button primary' }, buttonText);
+    let c2aBlock = a({ href: cardLink, 'aria-label': buttonText, class: 'button primary' }, buttonText);
     if (this.c2aLinkConfig) {
       c2aBlock = a(this.c2aLinkConfig, buttonText);
     }
     if (this.c2aLinkStyle) {
-      c2aBlock = a({ href: item.path, 'aria-label': buttonText }, buttonText);
+      c2aBlock = a({ href: cardLink, 'aria-label': buttonText }, buttonText);
       c2aBlock.append(
         this.c2aLinkIconFull
           ? i({ class: 'fa fa-chevron-circle-right', 'aria-hidden': true })
@@ -67,7 +68,7 @@ class Card {
     return (
       div({ class: 'card' },
         this.showImageThumbnail ? div({ class: 'card-thumb' },
-          this.thumbnailLink ? a({ href: item.path },
+          this.thumbnailLink ? a({ href: cardLink },
             thumbnailBlock,
           ) : thumbnailBlock,
         ) : '',
@@ -75,7 +76,7 @@ class Card {
         div({ class: 'card-caption' },
           item.type ? div({ class: 'card-type' }, item.type) : '',
           h3(
-            this.titleLink ? a({ href: item.path }, cardTitle) : cardTitle,
+            this.titleLink ? a({ href: cardLink }, cardTitle) : cardTitle,
           ),
           cardDescription ? p({ class: 'card-description' }, cardDescription) : '',
           p({ class: 'button-container' },

--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -74,6 +74,8 @@ export default async function decorate(block) {
   otherResources.forEach((item) => {
     const resourceType = item.type;
     const resourceImage = resourceMapping[item.type]?.image;
+    const resourceLink = (item.gated === 'Yes' && item.gatedURL && item.gatedURL !== '0')
+      ? item.gatedURL : item.path;
     const resourceBlock = div(
       {
         class: 'resource filtered-item',
@@ -105,7 +107,7 @@ export default async function decorate(block) {
           p(
             { class: 'resource-link' },
             a(
-              { href: item.path },
+              { href: resourceLink },
               `${resourceMapping[resourceType].action} ${resourceType}`,
               i({ class: 'fa fa-chevron-circle-right' }),
             ),


### PR DESCRIPTION
Fix #378 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers
- After: https://378-card-gatedurl--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers
