### PR TITLE
Allow vidyard video in 'About Us' page to take full width

### DIFF
--- a/templates/about-us/about-us.css
+++ b/templates/about-us/about-us.css
@@ -15,6 +15,10 @@
   font-size: 36px;
 }
 
+.about-us main .vidyard {
+  max-width: unset;
+}
+
 @media only screen and (max-width: 991px) {
   .about-us .section .default-content-wrapper h2 {
     font-size: 45px;

--- a/templates/about-us/about-us.css
+++ b/templates/about-us/about-us.css
@@ -15,7 +15,7 @@
   font-size: 36px;
 }
 
-.about-us main .vidyard {
+.about-us main .section[data-name="about-us"] .vidyard {
   max-width: unset;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #421

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/about-us
- After: https://aboutus-vidyard--moleculardevices--hlxsites.hlx.live/about-us
