### PR TITLE
feat: dropdown filters of resources on mobile

### DIFF
--- a/blocks/resources/resources.css
+++ b/blocks/resources/resources.css
@@ -156,11 +156,11 @@ main .section .resources-wrapper {
   .resources li.filter[aria-selected='true'] {
     display: block;
     order: -1;
-    color: #0066a4;
+    color: var(--link-hover-color);
   }
 
   .resources li.filter[aria-selected='true'] a {
-    color: #0066a4;
+    color: var(--link-hover-color);
   }
 
   .resources li.filter[aria-selected='true'] .icon.icon-chevron-right-outline {

--- a/blocks/resources/resources.css
+++ b/blocks/resources/resources.css
@@ -86,13 +86,23 @@ main .section .resources-wrapper {
   color: var(--text-color);
 }
 
-.resources .filter a[aria-selected='true'] {
+.resources .filter[aria-selected='true'] a {
   text-decoration: underline;
   font-weight: 600;
 }
 
 .resources .filter-divider {
   margin: 0 15px;
+}
+
+.resources .icon.icon-chevron-right-outline {
+  height: 20px;
+  width: 20px;
+  float: right;
+  padding: 0;
+  transform: rotate(90deg);
+  margin-left: 10px;
+  display: none;
 }
 
 .resources .resource[aria-hidden='true'],
@@ -120,5 +130,44 @@ main .section .resources-wrapper {
 
   .resources li.filter {
     margin-bottom: 5px;
+  }
+}
+
+@media only screen and (max-width: 991px) {
+  .resources .filters {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .resources .filter-divider {
+    display: none;
+  }
+
+  .resources li.filter {
+    display: none;
+    text-align: left;
+    padding: 5px 30px;
+  }
+
+  .resources .filters.dropdown li.filter {
+    display: block;
+  }
+
+  .resources li.filter[aria-selected='true'] {
+    display: block;
+    order: -1;
+    color: #0066a4;
+  }
+
+  .resources li.filter[aria-selected='true'] a {
+    color: #0066a4;
+  }
+
+  .resources li.filter[aria-selected='true'] .icon.icon-chevron-right-outline {
+    display: block;
+  }
+
+  .resources .filters.dropdown li.filter[aria-selected='true'] .icon.icon-chevron-right-outline {
+    transform: rotate(270deg);
   }
 }

--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -2,7 +2,7 @@ import {
   div, a, p, h3, i, h2, span, ul, li,
 } from '../../scripts/dom-helpers.js';
 import ffetch from '../../scripts/ffetch.js';
-import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, decorateIcons, getMetadata } from '../../scripts/lib-franklin.js';
 import { embedVideo, fetchFragment } from '../../scripts/scripts.js';
 import resourceMapping from './resource-mapping.js';
 
@@ -15,12 +15,18 @@ const relatedResourcesHeaders = {
 function handleFilterClick(e) {
   e.preventDefault();
   const { target } = e;
-  const selected = target.getAttribute('aria-selected') === 'true';
+  const targetFilter = target.closest('li.filter');
+
+  // toggle filters dropdown on mobile
+  const targetFilters = target.closest('.filters');
+  targetFilters.classList.toggle('dropdown');
+
+  const selected = targetFilter.getAttribute('aria-selected') === 'true';
   if (!selected) {
-    const resourceType = target.getAttribute('aria-labelledby');
-    const allFilters = document.querySelectorAll('.filter a');
+    const resourceType = targetFilter.getAttribute('aria-labelledby');
+    const allFilters = document.querySelectorAll('.filter');
     allFilters.forEach((item) => item.setAttribute('aria-selected', false));
-    target.setAttribute('aria-selected', true);
+    targetFilter.setAttribute('aria-selected', true);
     if (resourceType === 'View All') {
       const filteredResources = document.querySelectorAll('.filtered-item');
       filteredResources.forEach((item) => item.setAttribute('aria-hidden', false));
@@ -57,16 +63,24 @@ export default async function decorate(block) {
   sortedFilters.unshift('View All');
 
   sortedFilters.forEach((filter, idx) => {
-    filtersBlock.append(li({ class: 'filter' },
-      span({ class: 'filter-divider' }, idx === 0 ? '' : '|'),
-      a({
+    filtersBlock.append(
+      li({
+        class: 'filter',
         'aria-labelledby': filter,
-        href: '#',
         'aria-selected': idx === 0,
         onclick: handleFilterClick,
+      },
+      span({ class: 'filter-divider' }, idx === 0 ? '' : '|'),
+      a({
+        href: '#',
       }, filter),
-    ));
+      span({ class: 'icon icon-chevron-right-outline' }),
+      ),
+    );
   });
+  if (window.matchMedia('only screen and (max-width: 767px)').matches) {
+    decorateIcons(filtersBlock);
+  }
 
   block.append(filtersBlock);
 


### PR DESCRIPTION
Fix #367 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#resources
- After: https://367-resources-filters-mobile--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#resources

AND:
https://367-resources-filters-mobile--moleculardevices--hlxsites.hlx.live/applications/3d-cell-models/organoids/intestinal-organoids#resources

Note: the dropdown icon is only decorated on mobile view. Hence if you test by resizing window width you won't see it. Reloading the page on mobile to see the difference. This is intended for best performance.