### PR TITLE
fix: temporary URL for sitemap.xml

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,6 +1,6 @@
 sitemaps:
   website:
-    origin: https://main--moleculardevices--hlxsites.hlx.page
+    origin: https://franklin.moleculardevices.com
     source: /query-index.json
     destination: /sitemap.xml
     lastmod: YYYY-MM-DD


### PR DESCRIPTION
Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/
- After: https://sitemap-url--moleculardevices--hlxsites.hlx.live/
