### PR TITLE
fix: "Videos and Webinars" filter but no videos

### DIFF
--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -58,7 +58,9 @@ export default async function decorate(block) {
   const filtersBlock = ul({ class: 'filters' });
   const filters = [...new Set(otherResources.map((item) => item.type))]
     .filter((item) => item !== 'Citation');
-  filters.push('Videos and Webinars');
+  if (videoResources.length > 0) {
+    filters.push('Videos and Webinars');
+  }
   const sortedFilters = filters.sort((x, y) => (x.toLowerCase() < y.toLowerCase() ? -1 : 1));
   sortedFilters.unshift('View All');
 


### PR DESCRIPTION
Fix #502 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/accessories-consumables/chroma-filters#resources
- After: https://502--moleculardevices--hlxsites.hlx.page/products/clone-screening/accessories-consumables/chroma-filters#resources

AND: https://502--moleculardevices--hlxsites.hlx.page/products/clone-screening/accessories-consumables/chroma-filters#resources
