### PR TITLE
feat: decorate single line em elements as captions

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -540,6 +540,20 @@ export function decorateButtons(element) {
 }
 
 /**
+ * decorates paragraphs containing a single em as captions.
+ * @param {Element} element container element
+ */
+
+export function decorateCaptions(element) {
+  element.querySelectorAll('em').forEach((em) => {
+    const up = em.parentElement;
+    if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
+      up.classList.add('caption-container');
+    }
+  })
+}
+
+/**
  * load LCP block and/or wait for LCP in default content.
  */
 export async function waitForLCP(lcpBlocks) {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -550,7 +550,7 @@ export function decorateCaptions(element) {
     if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
       up.classList.add('caption-container');
     }
-  })
+  });
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -2,6 +2,7 @@ import {
   sampleRUM,
   loadFooter,
   decorateButtons,
+  decorateCaptions,
   decorateIcons,
   decorateSections,
   decorateBlocks,
@@ -360,6 +361,7 @@ async function decorateTemplates(main) {
 export async function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
+  decorateCaptions(main);
   decorateIcons(main);
   optimiseHeroBlock(main);
   decorateSections(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -294,6 +294,10 @@ em strong {
   font-weight: 700;
 }
 
+.caption-container > em {
+  font-size: 14px;
+}
+
 .text-caption {
   margin: 15px 0 25px;
   font-size: var(--body-font-size-xs);


### PR DESCRIPTION
Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/app-note/bpd/diverse-utility-of-cloneselect-imager-in-label-free-applications
- After: https://decorate-captions--moleculardevices--hlxsites.hlx.page/en/assets/app-note/bpd/diverse-utility-of-cloneselect-imager-in-label-free-applications
