### PR TITLE
fix: side padding for card list heading on mobile

### DIFF
--- a/blocks/card-list/card-list.css
+++ b/blocks/card-list/card-list.css
@@ -84,6 +84,10 @@ main .card-list .carousel-item .card {
     padding: 0 10%;
   }
 
+  main .section.card-list-container .default-content-wrapper h2 {
+    padding: 0 15px;
+  }
+
   main .card-list .carousel-item {
     flex: 1 0 100%;
     width: 100%;


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/technology
- After: https://mobile-heading-padding--moleculardevices--hlxsites.hlx.page/technology