### PR TITLE
544 - [Product] Navigating to other page tabs shows no data

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,7 +15,6 @@ import {
   loadHeader,
   decorateBlock,
   buildBlock,
-  updateSectionsStatus,
 } from './lib-franklin.js';
 import { a, div, p } from './dom-helpers.js';
 
@@ -249,9 +248,7 @@ function lazyLoadHiddenPageNavTabs(sections, nameOfFirstSection) {
           block.parentElement.style.display = '';
         });
 
-        // should set the status of section as loaded using standard lib-franklin logic
-        updateSectionsStatus(document.querySelector('main'));
-        // force the loaded status just as a double precaution
+        // force the loaded status of the section
         section.setAttribute('data-section-status', 'loaded');
       };  
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,7 @@ import {
   loadHeader,
   decorateBlock,
   buildBlock,
+  updateSectionsStatus,
 } from './lib-franklin.js';
 import { a, div, p } from './dom-helpers.js';
 
@@ -247,7 +248,9 @@ function lazyLoadHiddenPageNavTabs(sections, nameOfFirstSection) {
           // Show the block only when everything is ready to avoid CLS
           block.parentElement.style.display = '';
         });
-      };
+
+        updateSectionsStatus(document.querySelector('main'));
+      };  
 
       // In case the user clicks on the section, quickly render it on the spot,
       // if it happens before the timeout bleow

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -249,7 +249,10 @@ function lazyLoadHiddenPageNavTabs(sections, nameOfFirstSection) {
           block.parentElement.style.display = '';
         });
 
+        // should set the status of section as loaded using standard lib-franklin logic
         updateSectionsStatus(document.querySelector('main'));
+        // force the loaded status just as a double precaution
+        section.setAttribute('data-section-status', 'loaded');
       };  
 
       // In case the user clicks on the section, quickly render it on the spot,

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -250,7 +250,7 @@ function lazyLoadHiddenPageNavTabs(sections, nameOfFirstSection) {
 
         // force the loaded status of the section
         section.setAttribute('data-section-status', 'loaded');
-      };  
+      };
 
       // In case the user clicks on the section, quickly render it on the spot,
       // if it happens before the timeout bleow


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #544

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager

- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#applications
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#applications

- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#specifications-options
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#specifications-options

- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#resources
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#resources

- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#citations
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#citations

- Before: https://main--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#related-products-services
- After: https://fix-544--moleculardevices--hlxsites.hlx.live/products/clone-screening/mammalian-screening/cloneselect-imager#related-products-services
