### PR TITLE
Partial - 516 - [Newsroom] Overview page years of the past - news only

### DIFF
--- a/blocks/latest-news/latest-news.js
+++ b/blocks/latest-news/latest-news.js
@@ -2,15 +2,11 @@ import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 import ffetch from '../../scripts/ffetch.js';
 // eslint-disable-next-line object-curly-newline
 import { article, a, div, p } from '../../scripts/dom-helpers.js';
-
-export function formatDate(date) {
-  const dateObj = new Date(Date.UTC(0, 0, 0, 0, 0, date));
-  return dateObj.toLocaleDateString('en-US', { month: 'short', day: '2-digit', year: 'numeric' });
-}
+import { formatDateUTCSeconds } from '../../scripts/scripts.js';
 
 export function buildList(data, block) {
   data.forEach((item, idx) => {
-    let dateLine = formatDate(item.date);
+    let dateLine = formatDateUTCSeconds(item.date);
     if (item.publisher) dateLine += ` | ${item.publisher}`;
     block.append(article({},
       div({ class: 'image' },

--- a/blocks/news-carousel/news-carousel.js
+++ b/blocks/news-carousel/news-carousel.js
@@ -1,17 +1,7 @@
 import ffetch from '../../scripts/ffetch.js';
 import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
+import { formatDateUTCSeconds } from '../../scripts/scripts.js';
 import { createCarousel } from '../carousel/carousel.js';
-
-function formatDate(newsDate) {
-  const dateObj = new Date(0);
-  dateObj.setUTCSeconds(newsDate);
-
-  return dateObj.toLocaleDateString('en-US', {
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric',
-  });
-}
 
 function renderItem(item) {
   const newsItem = document.createElement('div');
@@ -32,7 +22,7 @@ function renderItem(item) {
   const newsCaptionText = document.createElement('div');
   newsCaptionText.classList.add('news-carousel-caption-text');
   newsCaptionText.innerHTML = `
-    <p>${formatDate(item.date)}</p>
+    <p>${formatDateUTCSeconds(item.date)}</p>
     <p>${item.title}</p>
   `;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -415,6 +415,12 @@ export function addFavIcon(href, rel = 'icon') {
   }
 }
 
+/**
+ * Format date expressed as string: mm/dd/yyyy
+ * @param {string} dateStr date as string
+ * @param {Object} options result string format options
+ * @returns new string with the formated date
+ */
 export function formatDate(dateStr, options = {}) {
   if (!dateStr) return '';
   const parts = dateStr.split(/[/,]/);
@@ -429,6 +435,23 @@ export function formatDate(dateStr, options = {}) {
     });
   }
   return dateStr;
+}
+
+/**
+ * Format date expressed in UTC seconds
+ * @param {number} date
+ * @returns new string with the formated date
+ */
+export function formatDateUTCSeconds(date, options = {}) {
+  const dateObj = new Date(0);
+  dateObj.setUTCSeconds(date);
+
+  return dateObj.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    ...options,
+  });
 }
 
 export function unixDateToString(unixDateString) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Partial #516.

Contains the fix for news only.
Events unfortunately are timezone specific so they need more complex logic...  Trying to use the same logic for them results in dates which are sometimes 1 day off..

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/newsroom
- After: https://partial-516--moleculardevices--hlxsites.hlx.live/newsroom
