### PR TITLE
fix: newsroom hero image too short

### DIFF
--- a/templates/newsroom/newsroom.css
+++ b/templates/newsroom/newsroom.css
@@ -1,8 +1,3 @@
-.newsroom .newsroom main .section>.featured-posts-wrapper {
-  padding-top: 0;
-  padding-bottom: 50px;
-}
-
 .newsroom main .section h2 {
   --heading-font-size-xl: 42px;
 
@@ -59,6 +54,22 @@
 @media (min-width: 992px) {
   .newsroom main .section {
     --newsroom-section-width: 970px;
+  }
+
+  .newsroom main .section.hero-container .hero-inner .container {
+    padding-bottom: 220px;
+  }
+  
+  .newsroom main .section.hero-container .hero-inner .container.two-column {
+    padding-bottom: 80px;
+  }  
+
+  .newsroom main .section.hero-container .hero-inner .container.two-column > div:nth-child(1) {
+    width: 35%;
+  }
+  
+  .newsroom main .section.hero-container .hero-inner .container.two-column > div:nth-child(2) {
+    width: 65%;
   }
 }
 


### PR DESCRIPTION
Fix #512 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/newsroom/news
- After: https://512--moleculardevices--hlxsites.hlx.page/newsroom/news

AND: https://512--moleculardevices--hlxsites.hlx.page/newsroom/in-the-news
