### PR TITLE
[Newsroom] Overview page h2 spaces missing left and right

### DIFF
--- a/templates/newsroom/newsroom.css
+++ b/templates/newsroom/newsroom.css
@@ -31,6 +31,13 @@
   padding-right: 15px;
 }
 
+@media (max-width: 767px) {
+  .newsroom main .section h2 {
+    margin-left: 20px;
+    margin-right: 20px;
+  }
+}
+
 @media (min-width: 768px) {
   .newsroom main .section {
     --newsroom-section-width: 750px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #586

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/newsroom
- After: https://newsroom-h2-mobile--moleculardevices--hlxsites.hlx.page/newsroom
