### PR TITLE
[Newsroom] Overview page links missing chevron right icon

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -43,10 +43,6 @@
   color: var(--text-color);
 }
 
-.footer i {
-  margin-left: 5px;
-}
-
 .row-5 i {
   margin: 0;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -411,6 +411,10 @@ button.secondary:focus {
   box-shadow: 0 0 10px 1px rgb(0 0 0 / 20%);
 }
 
+a i.fa {
+  padding-left: 5px;
+}
+
 main input {
   font-size: 1.25rem;
   width: 100%;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -412,7 +412,7 @@ button.secondary:focus {
 }
 
 a i.fa {
-  padding-left: 5px;
+  margin-left: 5px;
 }
 
 main input {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -712,7 +712,6 @@ main .event-container i.fa.fa-external-link {
   position: relative;
   top: -7px;
   font-size: 13px;
-  margin-left: 2px;
 }
 
 main .section .default-content-wrapper h2:only-child {

--- a/templates/newsroom/newsroom.css
+++ b/templates/newsroom/newsroom.css
@@ -31,10 +31,6 @@
   padding-right: 15px;
 }
 
-.newsroom main .section .default-content-wrapper .button-container a i {
-  padding-left: 5px;
-}
-
 @media (max-width: 767px) {
   .newsroom main .section h2 {
     margin-left: 20px;

--- a/templates/newsroom/newsroom.css
+++ b/templates/newsroom/newsroom.css
@@ -32,7 +32,7 @@
 }
 
 .newsroom main .section .default-content-wrapper .button-container a i {
-  padding-left: 5px,
+  padding-left: 5px;
 }
 
 @media (max-width: 767px) {

--- a/templates/newsroom/newsroom.css
+++ b/templates/newsroom/newsroom.css
@@ -31,6 +31,10 @@
   padding-right: 15px;
 }
 
+.newsroom main .section .default-content-wrapper .button-container a i {
+  padding-left: 5px,
+}
+
 @media (max-width: 767px) {
   .newsroom main .section h2 {
     margin-left: 20px;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #514

Cleanup existing styles:
- Footer
- News 

Not touched styles:
Header / Company Links, because the icons are not embedded in a link

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/newsroom
- After: https://newsroom-icons--moleculardevices--hlxsites.hlx.page/newsroom

- Before: https://main--moleculardevices--hlxsites.hlx.page/newsroom/news/hub-organoids-to-advance-automated-intestinal-organoid-screening-technology
- After: https://newsroom-icons--moleculardevices--hlxsites.hlx.page/newsroom/news/hub-organoids-to-advance-automated-intestinal-organoid-screening-technology
