### PR TITLE
fix: paragraph styling on customer breakthrough pages

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -23,6 +23,7 @@ import { a, div, p } from './dom-helpers.js';
  */
 const TEMPLATE_LIST = [
   'application-note',
+  'customer-breakthrough',
   'news',
   'publication',
   'blog',

--- a/templates/customer-breakthrough/customer-breakthrough.css
+++ b/templates/customer-breakthrough/customer-breakthrough.css
@@ -1,0 +1,11 @@
+.customer-breakthrough main .default-content-wrapper {
+  margin-bottom: 50px;
+}
+
+.customer-breakthrough main .hero-container + .section > .default-content-wrapper:first-child {
+  margin: 0 auto;
+}
+
+.customer-breakthrough main .default-content-wrapper p + h2 {
+  margin-top: 50px;
+}


### PR DESCRIPTION
Fix #492 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/br/ribopro
- After: https://492--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/br/ribopro

AND: https://492--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/br/apreslabs