### PR TITLE
trivial: clean up redundant styling of chevron link icon

### DIFF
--- a/blocks/applications-carousel/applications-carousel.css
+++ b/blocks/applications-carousel/applications-carousel.css
@@ -50,10 +50,6 @@ main .carousel.applications-carousel {
   color: #008ca8;
 }
 
-.carousel.applications-carousel .card .button-container a .fa {
-  margin-left: 5px;
-}
-
 @media only screen and (max-width: 1200px) {
   main .carousel-wrapper.applications-carousel-wrapper {
     width: 940px;

--- a/blocks/featured-products-carousel/featured-products-carousel.css
+++ b/blocks/featured-products-carousel/featured-products-carousel.css
@@ -67,10 +67,6 @@ main .featured-products-carousel.mini .carousel-item-text a {
   color: #008ca8;
 }
 
-main .featured-products-carousel.mini .carousel-item-text a .fa {
-  margin-left: 5px;
-}
-
 main .featured-products-carousel.mini .carousel-item-columns-container {
   flex-direction: column;
 }

--- a/blocks/related-applications/related-applications.css
+++ b/blocks/related-applications/related-applications.css
@@ -50,10 +50,6 @@ li.related-link::marker {
   width: 100%;
 }
 
-.related-app a .fa {
-  margin-left: 5px;
-}
-
 @media (max-width: 992px) {
   .related-app {
     flex-basis: 100%;

--- a/blocks/related-products/related-products.css
+++ b/blocks/related-products/related-products.css
@@ -59,10 +59,6 @@ main .section .related-products-wrapper {
   color: #008ca8;
 }
 
-.related-products .card .button-container a .fa {
-  margin-left: 5px;
-}
-
 @media only screen and (max-width: 992px) {
   .related-products .card {
     width: 45%;

--- a/blocks/resources/resources.css
+++ b/blocks/resources/resources.css
@@ -49,10 +49,6 @@ main .section .resources-wrapper {
   color: var(--button-bg-color);
 }
 
-.resources .resource-link a .fa {
-  margin-left: 5px;
-}
-
 .resources .video-resources-title {
   text-align: center;
 }

--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -39,10 +39,6 @@ main .section .specifications-wrapper {
   color: #008da9;
 }
 
-.specifications .product-heading a .fa {
-  margin-left: 5px;
-}
-
 .specifications .responsive-table th {
   text-align: left;
   padding: 15px;

--- a/blocks/wave-teaser/wave-teaser.css
+++ b/blocks/wave-teaser/wave-teaser.css
@@ -53,10 +53,6 @@ main .section.wave .wave-teaser .button-container {
   font-size: 22px;
 }
 
-.wave-teaser .button-container a .fa {
-  margin-left: 5px;
-}
-
 @media only screen and (max-width: 1199px) {
   .wave-teaser > div > div:last-child {
     max-width: 500px;


### PR DESCRIPTION
Follow up fix of #514 (PR #600)

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
- After: https://514-follow-up--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-imager
