### PR TITLE
607 - [Lab Notes] misaligned filter bar on the hero banner

### DIFF
--- a/blocks/card-list-filter/card-list-filter.css
+++ b/blocks/card-list-filter/card-list-filter.css
@@ -77,7 +77,7 @@
     background-color: rgba(0 0 0 / 50%);
     position: absolute;
     width: 100%;
-    bottom: 90px;
+    bottom: 115px;
     margin: 0;
   }
 
@@ -137,6 +137,8 @@
   .card-list-filter ul {
     display: block;
     padding: 0;
+    line-height: 1.33;
+    font-size: 14px;
   }
 
   .card-list-filter ul.hide {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #607

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/lab-notes
- After: https://607-filter--moleculardevices--hlxsites.hlx.live/lab-notes

- Before: https://main--moleculardevices--hlxsites.hlx.live/lab-notes/blog
- After: https://607-filter--moleculardevices--hlxsites.hlx.live/lab-notes/blog
