### PR TITLE
fix: headings for citations

### DIFF
--- a/blocks/citations/citations.css
+++ b/blocks/citations/citations.css
@@ -4,9 +4,10 @@ main .citations-container {
   padding: 90px 50px 50px;
 }
 
-main .citations-container h3 {
-  margin-top: 20px;
-  margin-bottom: 10px;
+main .citations-container .default-content-wrapper h3,
+.product main .citations-container .default-content-wrapper h3 {
+  margin: 25px 0 10px;
+  font-family: var(--ff-proxima-regular);
 }
 
 main .citations-container > .default-content-wrapper {
@@ -66,13 +67,18 @@ main .citations-container > .default-content-wrapper {
   margin: 0;
 }
 
+.product main .citations-container .default-content-wrapper h3 ~ p {
+  margin: 1em 0;
+}
+
 .citation em,
 .citations-container em {
   color: var(--text-green);
   font-style: normal;
 }
 
-.citations h2 {
+.citations .citation-header h2,
+.product .section.tabs .citations .citation-header h2 {
   padding-bottom: 15px;
   margin-bottom: 10px;
   margin-top: 10px;

--- a/blocks/citations/citations.js
+++ b/blocks/citations/citations.js
@@ -1,5 +1,6 @@
 import { fetchFragment } from '../../scripts/scripts.js';
-import { div, img } from '../../scripts/dom-helpers.js';
+import { div } from '../../scripts/dom-helpers.js';
+import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 
 function viewLongDescription(citation) {
   const shortDescriptionBlock = citation.querySelector('.citation-short-description');
@@ -84,7 +85,7 @@ function buildCitation(fragment) {
     { class: 'citation' },
     div(
       { class: 'citation-icon' },
-      img({ src: '/images/resource-icons/citation.png' }),
+      createOptimizedPicture('/images/resource-icons/citation.png', 'citation icon'),
     ),
     div(
       { class: 'citation-info' },


### PR DESCRIPTION
Fix #610

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-pico#citations
- After: https://cititations-heading--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-pico#citations

For reference, page was ok, nothing should change here
- Citations page: https://cititations-heading--moleculardevices--hlxsites.hlx.page/resources/citations/axon



