### PR TITLE
Issue-596 - Fix stacked-image-text to ensure big images fit to card size

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -91,6 +91,7 @@
 
 .cards.stacked-image-text img {
   aspect-ratio: auto;
+  width: auto;
 }
 
 .cards.stacked-image-text li {


### PR DESCRIPTION
Fix #596

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems
- After: https://issue-596--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems

Note: the spectra bot in the page looks broken, the fix for it is here: https://github.com/hlxsites/moleculardevices/pull/643