### PR TITLE
fix: Mobile Menu QA issues

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -636,9 +636,13 @@ header .mobile-menu .mobile-menu-subcategories .back-to-parent a::before {
   margin-top: -15px;
 }
 
+header .text-submenu a {
+  color: var(--text-white);
+}
+
 header .text-submenu ul > li > a {
   font-size: 11px;
-  color: #fff;
+  color: var(--text-white);
   border-bottom: 0;
   line-height: 15px;
   padding-left: 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,8 @@ import {
   loadHeader,
   decorateBlock,
   buildBlock,
+  readBlockConfig,
+  toCamelCase,
 } from './lib-franklin.js';
 import { a, div, p } from './dom-helpers.js';
 
@@ -672,5 +674,18 @@ const cookieParams = ['cmp', 'utm_medium', 'utm_source', 'utm_keyword', 'gclid']
 cookieParams.forEach((param) => {
   setCookieFromQueryParameters(param, 0);
 });
+
+export function processSectionMetadata(element) {
+  const sectionMeta = element.querySelector('.section-metadata');
+  if (sectionMeta) {
+    const meta = readBlockConfig(sectionMeta);
+    const keys = Object.keys(meta);
+    keys.forEach((key) => {
+      if (key === 'style') element.classList.add(toClassName(meta.style));
+      else element.dataset[toCamelCase(key)] = meta[key];
+    });
+    sectionMeta.remove();
+  }
+}
 
 loadPage();


### PR DESCRIPTION
Some of the menus in the mobile menu have different behaviours than others. This fixes the following QA issues:

>  In the mobile menu, please add links to the respective landing pages for "Products" and "Applications". Additionally, remove the first item from the submenus of "Resources" "Service & Support" and "Company."

>  In the mobile menu, remove the submenu arrows for "BLOG" and "Customer Breakthrough," under resources and link them directly to their respective landing pages.

>  In the mobile menu, under company remove the submenu arrows for "About us" "leadership" "Careers" and "events " and link them directly to their respective landing pages.



Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://fix-mobile-menu-issues--moleculardevices--hlxsites.hlx.page/
