### PR TITLE
chore - Optimise LCP

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -361,6 +361,8 @@ export function decorateSections(main) {
  * @param {Element} main The container element
  */
 export function updateSectionsStatus(main) {
+  if (!main) return;
+
   const sections = [...main.querySelectorAll(':scope > div.section')];
   for (let i = 0; i < sections.length; i += 1) {
     const section = sections[i];

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -603,6 +603,8 @@ export async function waitForLCP(lcpBlocks) {
       resolve();
     }
   });
+
+  updateSectionsStatus(document.querySelector('main'));
 }
 
 /**


### PR DESCRIPTION
In the Franklin lib code:
### The current sequence of calls is as following:
* loadEager
  * ...
  * WaitForLCP (loads the LCP defined block, **but doesn't display it**)
* loadLazy
  * loadHeader
  * loadBlocks
    * **updateSections** -> this is the first time when the LCP block is displayed, so it can be delayed by loadHeader.

### The proposed sequence of calls is:
* loadEager
  * ...
  * WaitForLCP (loads the LCP defined block, **but doesn't display it**)
    * **updateSections**
* loadLazy
  * loadHeader
  * loadBlocks
    * updateSections (works as before)


Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/video-gallery/cellular-imaging-systems
- After: https://optimise-lcp--moleculardevices--hlxsites.hlx.live/video-gallery/cellular-imaging-systems
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers
- After: https://optimise-lcp--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers
