### PR TITLE
Ensure "customers we serve" columns are shown as columns on desktop

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -141,17 +141,6 @@ main .section>div.columns-wrapper {
   vertical-align: top;
 }
 
-.section .columns.collaboration > div picture,
-.section .columns.collaboration > div img {
-  display: block;
-  margin: auto;
-}
-
-.section .columns.collaboration > div img,
-.columns.layout-20-80.partners-list-columns ul li img {
-  width: auto;
-}
-
 .columns.layout-20-80.partners-list-columns ul li picture,
 .columns.layout-20-80.partners-list-columns ul li img {
   display: block;
@@ -183,7 +172,7 @@ main .section>div.columns-wrapper {
   justify-content: center;
 }
 
-.columns.columns-3-cols:not(.innovation) {
+.columns.columns-3-cols:not(.innovation,.collaboration) {
   margin-left: -15px;
   margin-right: -15px;
 }
@@ -194,11 +183,6 @@ main .section>div.columns-wrapper {
 
 .columns.layout-20-80.extended-width:not(.green-separator) {
   margin-bottom: 80px;
-}
-
-.section .columns.collaboration > div {
-  display: block;
-  text-align: center;
 }
 
 .columns.columns-3-cols > div:not(:only-child) > div {
@@ -235,7 +219,16 @@ main .section>div.columns-wrapper {
   margin-bottom: 18px;
 }
 
-.section .columns.collaboration > div h3 {
+.columns.collaboration {
+  text-align: center;
+}
+
+.columns.collaboration .picture {
+  justify-content: center;
+  display: flex;
+}
+
+.columns.collaboration > div h3 {
   font-size: var(--heading-font-size-l);
   color: var(--text-green);
   font-family: inherit;


### PR DESCRIPTION
Fix #699 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/about-us#customers-we-serve
- After: https://issue-499--moleculardevices--hlxsites.hlx.page/about-us#customers-we-serve

Notes: the content was also addressed, it was originally created as a 3x3 matrix where each row represented a column on the UI, rather than 3 columns.