### PR TITLE
Prevent scroll animation when showing image gallery lightbox

### DIFF
--- a/blocks/image-gallery/image-gallery.js
+++ b/blocks/image-gallery/image-gallery.js
@@ -33,7 +33,8 @@ export default async function decorate(block) {
     row.querySelector('img:first-of-type').addEventListener('click', () => {
       wrapper.parentElement.classList.add('overlay');
       body.classList.add('no-scroll');
-      scroll((wrapper.offsetWidth * (i)));
+
+      document.body.scrollLeft = wrapper.offsetWidth * i;
     });
   });
   await decorateIcons(wrapper);


### PR DESCRIPTION
Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal
- After: https://fix-gallery-scroll--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal
