### PR TITLE
fix: only load GTM on prod urls

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -88,7 +88,9 @@ function loadGTM() {
 }
 
 loadUserData();
-loadGTM();
-if (!document.location.hostname.match('www.moleculardevices.com.cn') && !document.location.hostname.match('.hlx.page')) {
+if (!window.location.hostname.includes('localhost') && !document.location.hostname.includes('.hlx.page')) {
+  loadGTM();
+}
+if (!window.location.hostname.includes('localhost') && !document.location.hostname.match('.hlx.page') && !document.location.hostname.match('www.moleculardevices.com.cn')) {
   LoadDriftWidget();
 }


### PR DESCRIPTION

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/

No GTM loaded
- After: https://gtm-prod--moleculardevices--hlxsites.hlx.page/

GTM loaded
- After: https://gtm-prod--moleculardevices--hlxsites.hlx.live/
