### PR TITLE
chore: fix request quote button in hero display

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -71,7 +71,7 @@ function detectPricingRequestAvailable() {
 }
 
 function showHidePricingRequestButton(block) {
-  const pricingRequestButton = block.querySelector('a[href*="/quote-request"]');
+  const pricingRequestButton = block.querySelector('a[href*="/quote-request"][href*="type=quote"]');
   if (!pricingRequestButton) return;
 
   const pricintRequestButtonContainer = pricingRequestButton.closest('.button-container');


### PR DESCRIPTION
Fix #878

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/3d-biology/custom-organoid-expansion-service


Button "Speak to a specialist" as always visible
- After: https://hero-buttons--moleculardevices--hlxsites.hlx.page/products/3d-biology/custom-organoid-expansion-service#

Button "Request pricing" is only visible in EU & US
- After: https://hero-buttons--moleculardevices--hlxsites.hlx.page/products/flipr-penta-high-throughput-cellular-screening-system/screenworks-software
