### PR TITLE
903 - [Geo Sites] Page section tabs for products/applications

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -365,7 +365,8 @@ export function decorateSections(main) {
         } else if (key === 'name') {
           // section.id = toClassName(meta[key]);
           section.dataset[toCamelCase(key)] = toClassName(meta[key]);
-          section.title = meta[key];
+          const tabLink = document.querySelector(`.page-tabs a[href="#${toClassName(meta[key])}"`);
+          section.title = tabLink ? tabLink.textContent : meta[key];
         } else {
           section.dataset[toCamelCase(key)] = meta[key];
         }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #903

This is implementation option 1 , where we change the page tab block to have a list of links with the correct hash in the content and for which the link text will be translated.

<img width="643" alt="Screenshot 2023-07-14 at 16 20 56" src="https://github.com/hlxsites/moleculardevices/assets/3651689/4ceaa37d-2a2d-46d8-b750-fd9db359aa9c">

The code is written in such a way that if a section is added without the link in the page tab, it will still be added as a best effort, just that in the translated websites it will remain in english. This functionality can be of course removed if we don't like it*.

➕ directly in the word document - super clear where it is used and what for
➕ we already use that for other static filters (e.g. card list filters block) 
➖ needs to be done manually for each page individually, because links need to be set for that page specifically - can be error prone
➖ if you forget one, the content is not displayed (*only if we do the removal)

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers1
- After: https://translated-tabs1--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers1
