### PR TITLE
903 - [Geo Sites] Page section tabs for products/applications

### DIFF
--- a/blocks/page-tabs/page-tabs.js
+++ b/blocks/page-tabs/page-tabs.js
@@ -13,7 +13,7 @@ function openTab(target) {
     openContent.forEach((tab) => tab.setAttribute('aria-hidden', true));
     // open clicked tab
     parent.setAttribute('aria-selected', true);
-    const tabs = main.querySelectorAll(`div.section[aria-labelledby="${target.id}"]`);
+    const tabs = main.querySelectorAll(`div.section[aria-labelledby="${target.getAttribute('href').substring(1)}"]`);
     tabs.forEach((tab) => tab.setAttribute('aria-hidden', false));
   }
 }
@@ -31,7 +31,6 @@ async function createTabList(sections, active) {
         li({ 'aria-selected': sectionName === active },
           a({
             href: `#${sectionName}`,
-            id: sectionName,
             onclick: (e) => { openTab(e.target); },
           },
           section.title,


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #903

This is implementation option 2, where we use the placeholders feature to have the page tabs translated.

✔️ easier to manage - can be set in one place
➖ can be confusing which string is used where, because it is a key-value xcel (the value is not next to the content)
~➖ requires an additional request~, BUT managed to delay it for later to not increase the LCP, by using first the english value and evaluating placeholders only in the page-tab block and replacing the value if it exists in the map. https://github.com/hlxsites/moleculardevices/pull/913/files#diff-950969313e9ab20d1b5804a70aeba1b394e38588ea7bb909a426cb57dfb47911R28

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers
- After: https://translated-tabs2--moleculardevices--hlxsites.hlx.live/products/microplate-readers/multi-mode-readers/spectramax-id3-id5-readers
