### PR TITLE
fix: paragraph margin in hero

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -109,7 +109,7 @@ main .hero-advanced-wrapper {
   line-height: 1.5;
 }
 
-.hero-inner .two-column h6+p {
+.hero-inner .two-column h6~p {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>. where to verify: in the second column under "TEAM MEMBERS", all names should be listed without spaces between them.

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/dd/img/visikol
- After: https://hero-h6-p--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/dd/img/visikol
