### PR TITLE
chore: update specifications block for latest specifications data

### DIFF
--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -6,6 +6,7 @@ main .section .specifications-wrapper {
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
+  margin-bottom: 50px;
 }
 
 .specifications .table-container::-webkit-scrollbar {

--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -1,12 +1,12 @@
 main .section .specifications-wrapper {
   padding-top: 0;
+  margin-bottom: 50px;
 }
 
 .specifications .table-container {
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
-  margin-bottom: 50px;
 }
 
 .specifications .table-container::-webkit-scrollbar {

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -54,19 +54,26 @@ export default async function decorate(block) {
   const tBodyBlock = domEl('tbody');
   categories.forEach((dataName) => {
     const groupData = specData[dataName];
+    // do nothing if the group data does not contain at least one label and one value array
+    if (groupData.data.length < 2) {
+      return;
+    }
     const attrs = Object.keys(groupData.data[0] || {});
     attrs.forEach((attr) => {
-      if (attr === 'path') {
+      if (['key', 'path', 'identifier'].includes(attr)) {
         return;
       }
       const thisRow = domEl('tr');
-      if (attr === 'Name') {
+      if (attr === 'name') {
         thisRow.append(domEl('td',
-          h3(groupData.data[0].Name)),
+          h3(groupData.data[1].name)),
         );
       } else {
-        thisRow.append(domEl('td', attr));
+        thisRow.append(domEl('td', groupData.data[0][attr]));
         groupData.data.forEach((item) => {
+          if (item.key === 'label') {
+            return;
+          }
           let rowValue = item[attr];
           rowValue = rowValue.replace(/true/gi, '<img src="/images/check-icon.png" alt="true" width="30" height="30">');
           rowValue = rowValue.replace(/false/gi, '<img src="/images/false-icon.png" alt="false" width="30" height="30">');


### PR DESCRIPTION
Fix #901 

Test URLs:

- Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options
- After: https://901-specs--moleculardevices--hlxsites.hlx.live/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options

AND: https://901-specs--moleculardevices--hlxsites.hlx.live/products/flipr-penta-high-throughput-cellular-screening-system#specifications-options

AND: https://901-specs--moleculardevices--hlxsites.hlx.live/products/microplate-readers/absorbance-readers/spectramax-abs-plate-readers#specifications-options