### PR TITLE
fix: bg for resizeable iframe

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -98,5 +98,5 @@ main .embed.embed-twitter > div {
 }
 
 main .embed.embed-info-moleculardevices-com {
-  height: 590px;
+  min-height: 590px;
 }


### PR DESCRIPTION
Fix #763

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/bpd/monoclonality-assurance-using-cloneselect-single-cell-printer-and-cloneselect-imager-in-human-stem-cell
- After: https://landing-iframe--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/bpd/monoclonality-assurance-using-cloneselect-single-cell-printer-and-cloneselect-imager-in-human-stem-cell
