### PR TITLE
fix: fix breadcrumb for news & event pages

### DIFF
--- a/blocks/breadcrumbs/breadcrumbs-create.js
+++ b/blocks/breadcrumbs/breadcrumbs-create.js
@@ -110,6 +110,10 @@ const customBreadcrumbs = {
     name: 'Resources',
     url_path: '/search-results',
   },
+  events: {
+    name: 'Events',
+    url_path: '/events',
+  },
 };
 
 function getCustomUrl(path, part) {

--- a/blocks/breadcrumbs/breadcrumbs.css
+++ b/blocks/breadcrumbs/breadcrumbs.css
@@ -5,6 +5,12 @@
   padding-bottom: 30px;
 }
 
+.news main .breadcrumbs,
+.publication main .breadcrumbs,
+.events main .breadcrumbs {
+  padding-top: 70px;
+}
+
 .breadcrumbs ol {
   padding: 0;
   margin: 0;
@@ -28,6 +34,7 @@
 }
 
 .breadcrumbs li a {
+  color: var(--text-color);
   cursor: pointer;
 }
 

--- a/blocks/breadcrumbs/breadcrumbs.js
+++ b/blocks/breadcrumbs/breadcrumbs.js
@@ -1,5 +1,7 @@
+import { ol } from '../../scripts/dom-helpers.js';
 import createBreadcrumbs from './breadcrumbs-create.js';
 
 export default async function decorate(block) {
+  block.replaceChildren(ol());
   await createBreadcrumbs(block);
 }

--- a/blocks/publication/publication.css
+++ b/blocks/publication/publication.css
@@ -1,4 +1,11 @@
 main .publication-container {
   background-color: var(--grey-background-color);
 }
-    
+
+main .publication-container .description {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Fix #978

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/newsroom/in-the-news/cell-cultured-meat-where-are-we-now
- After: https://fix-breadcumb--moleculardevices--hlxsites.hlx.page/newsroom/in-the-news/cell-cultured-meat-where-are-we-now
- After: https://fix-breadcumb--moleculardevices--hlxsites.hlx.page/newsroom/news/society-for-laboratory-automation-and-screening-2023-international-conference-and-exhibition
- After: https://fix-breadcumb--moleculardevices--hlxsites.hlx.page/events/labdays-aarhus-2023

