### PR TITLE
chore: fix resource mapping for news

### DIFF
--- a/blocks/resources/resource-mapping.js
+++ b/blocks/resources/resource-mapping.js
@@ -39,6 +39,10 @@ export default {
     image: 'infographic',
     action: 'downloadInfographic',
   },
+  News: {
+    image: 'document',
+    action: 'readNews',
+  },
   Presentations: {
     image: 'presentations',
     action: 'downloadPresentations',


### PR DESCRIPTION
Before: news where missing on the resources tab

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/3d-biology/custom-organoid-expansion-service#resources
- After: https://resource-mapping--moleculardevices--hlxsites.hlx.page/products/3d-biology/custom-organoid-expansion-service#resources