### PR TITLE
fix: no external link for non HTTP links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -204,7 +204,8 @@ function decorateExternalLink(link) {
     'http://pi.pardot.com',
   ];
 
-  if (url.origin === window.location.origin
+  if (url.origin === 'null'
+    || url.origin === window.location.origin
     || internalLinks.includes(url.origin)) {
     return;
   }


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs (check View Interactive Demo button):
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-pico
- After: https://981-followup--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-pico
