### PR TITLE
Add gap of 20px between feature items

### DIFF
--- a/blocks/image-list/image-list.css
+++ b/blocks/image-list/image-list.css
@@ -22,6 +22,7 @@ main div.image-list-wrapper {
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: 30px;
+  row-gap: 20px;
 }
 
 .image-list.block > div {


### PR DESCRIPTION
Fix #979 (last comment in the issue)

Test URLs:
Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal#options
After: https://issue-979-2--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal#options

Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal
After: https://issue-979-2--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal
