### PR TITLE
chore: Index Search Title metadata

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -124,6 +124,9 @@ indices:
       specifications:
         select: head > meta[name="specifications"]
         value: attribute(el, "content")
+      searchTitle:
+        select: head > meta[name="search-title"]
+        value: attribute(el, "content")
       productFinderFilter1:
         select: head > meta[name="pf-filter-1"]
         value: attribute(el, "content")


### PR DESCRIPTION
The Search Title is needed for the coveo information indexing. 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://index-search-title--moleculardevices--hlxsites.hlx.page/
