### PR TITLE
[Translation] Use placeholders for Step 2 in the Product Finder #1054

### DIFF
--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -16,8 +16,6 @@ const DEFAULT_TITLE = 'Select a Product Type';
 const DEFAULT_CATEGORY_TITLE = 'Select {{tab}} Category';
 const PRODUCT_FINDER_URL = '/product-finder/product-finder.json';
 
-const lang = (document.querySelector('html[lang]')) ? document.querySelector('html').getAttribute('lang') : 'en';
-
 let placeholders = {};
 let step2Type = '';
 let step2Title = '';
@@ -57,7 +55,7 @@ async function renderIconCards(listArr, progressStep, tabName, callback) {
   });
 
   listArr.forEach((item) => {
-    item.title = progressStep === `${STEP_PREFIX}-1` ? item.title : item.category;
+    item.title = progressStep === `${STEP_PREFIX}-1` ? item.title : item.displayCategory;
     item.id = toClassName(item.type);
   });
 
@@ -204,7 +202,7 @@ async function stepThree(e) {
   root.setAttribute('data-type', type);
   root.setAttribute('data-category', category);
 
-  const dataCardType = getListIdentifier(`${type}-${category}-products-${lang}`);
+  const dataCardType = getListIdentifier(`${type}-${category}-products`);
   const lists = root.querySelectorAll('.product-finder-list');
   lists.forEach((list) => {
     const listCardType = list.attributes['data-card-type'].value;
@@ -303,7 +301,7 @@ async function stepTwo(e) {
   );
 
   // generate the icons only once
-  const dataCardType = getListIdentifier(`${type}-${lang}`);
+  const dataCardType = getListIdentifier(`${type}`);
 
   // get all product-finder-list
   const lists = root.querySelectorAll('.product-finder-list');

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -361,8 +361,7 @@ export default async function decorate(block) {
           const activeSteps = document.querySelectorAll('.product-finder-step-wrapper.active');
           activeSteps.forEach((activeStep) => {
             activeStep.classList.remove(ACTIVE_CLASS);
-            activeStep.classList.add(HIDDEN_CLASS);
-            activeStep.style.removeProperty('display');
+            activeStep.style.display = 'none';
           });
           stepTwo(e);
         }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -358,6 +358,10 @@ export default async function decorate(block) {
           progressCustomTexts.forEach((progressCustomText) => {
             progressCustomText.remove();
           });
+          const activeSteps = document.querySelectorAll('.product-finder-step-wrapper.active');
+          activeSteps.forEach((activeStep) => {
+            activeStep.classList.remove(ACTIVE_CLASS).add(HIDDEN_CLASS);
+          });
           stepTwo(e);
         }
       }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -358,7 +358,6 @@ export default async function decorate(block) {
           progressCustomTexts.forEach((progressCustomText) => {
             progressCustomText.remove();
           });
-          document.querySelector('.product-finder-step-wrapper.active').classList.add(ACTIVE_CLASS);
           stepTwo(e);
         }
       }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -360,7 +360,8 @@ export default async function decorate(block) {
           });
           const activeSteps = document.querySelectorAll('.product-finder-step-wrapper.active');
           activeSteps.forEach((activeStep) => {
-            activeStep.classList.remove(ACTIVE_CLASS).add(HIDDEN_CLASS);
+            activeStep.classList.remove(ACTIVE_CLASS);
+            activeStep.classList.add(HIDDEN_CLASS);
           });
           stepTwo(e);
         }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -358,6 +358,7 @@ export default async function decorate(block) {
           progressCustomTexts.forEach((progressCustomText) => {
             progressCustomText.remove();
           });
+          document.querySelector('.product-finder-step-wrapper.active').classList.add(ACTIVE_CLASS);
           stepTwo(e);
         }
       }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -16,6 +16,8 @@ const DEFAULT_TITLE = 'Select a Product Type';
 const DEFAULT_CATEGORY_TITLE = 'Select {{tab}} Category';
 const PRODUCT_FINDER_URL = '/product-finder/product-finder.json';
 
+const lang = (document.querySelector('html[lang]')) ? document.querySelector('html').getAttribute('lang') : 'en';
+
 let placeholders = {};
 let step2Type = '';
 let step2Title = '';
@@ -202,7 +204,7 @@ async function stepThree(e) {
   root.setAttribute('data-type', type);
   root.setAttribute('data-category', category);
 
-  const dataCardType = getListIdentifier(`${type}-${category}-products`);
+  const dataCardType = getListIdentifier(`${type}-${category}-products-${lang}`);
   const lists = root.querySelectorAll('.product-finder-list');
   lists.forEach((list) => {
     const listCardType = list.attributes['data-card-type'].value;
@@ -301,7 +303,7 @@ async function stepTwo(e) {
   );
 
   // generate the icons only once
-  const dataCardType = getListIdentifier(`${type}`);
+  const dataCardType = getListIdentifier(`${type}-${lang}`);
 
   // get all product-finder-list
   const lists = root.querySelectorAll('.product-finder-list');

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -362,6 +362,7 @@ export default async function decorate(block) {
           activeSteps.forEach((activeStep) => {
             activeStep.classList.remove(ACTIVE_CLASS);
             activeStep.classList.add(HIDDEN_CLASS);
+            activeStep.style.removeProperty('display');
           });
           stepTwo(e);
         }

--- a/blocks/product-finder/product-finder.js
+++ b/blocks/product-finder/product-finder.js
@@ -13,6 +13,7 @@ const ACTIVE_CLASS = 'active';
 const HIDDEN_CLASS = 'hidden';
 const CHECKED_CLASS = 'checked';
 const DEFAULT_TITLE = 'Select a Product Type';
+const DEFAULT_CATEGORY_TITLE = 'Select {{tab}} Category';
 const PRODUCT_FINDER_URL = '/product-finder/product-finder.json';
 
 let placeholders = {};
@@ -138,7 +139,7 @@ function switchTab(tab, stepNum, prevStepNum, title) {
 
   if (title) {
     const titleEl = document.querySelector('.product-finder-wrapper .product-finder-tab-title');
-    titleEl.innerHTML = title.replace('tab', tab);
+    titleEl.innerHTML = title.replace('{{tab}}', tab);
   }
 
   document.querySelector(`.product-finder-container .progress-${prevStepNum}`).classList.add(CHECKED_CLASS);
@@ -295,7 +296,9 @@ async function stepTwo(e) {
 
   const stepNum = `${STEP_PREFIX}-2`;
   const prevStepNum = `${STEP_PREFIX}-1`;
-  const root = switchTab(title, stepNum, prevStepNum, 'Select tab Category');
+  // eslint-disable-next-line max-len
+  const root = switchTab(title, stepNum, prevStepNum, placeholders.selectTabCategory || DEFAULT_CATEGORY_TITLE,
+  );
 
   // generate the icons only once
   const dataCardType = getListIdentifier(`${type}`);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1054
+ additional fix for hiding the layer from step 3 when going back using the checkboxes from step select.

**Note: Added placeholder with a nested placeholder where I am not sure if this is allowed. It works locally.**:
See https://franklin.moleculardevices.com/placeholders.json
Key: `Select Tab Category`
Text: `Select {{tab}} Category`
Confirmed by TransPerfect, Christian, that these placeholders are valid.

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/product-finder
- After: https://1054-pf--moleculardevices--hlxsites.hlx.page/product-finder
