### PR TITLE
feat: Normalise Redirects URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,26 @@
   <head>
     <title>404: Page Not Found !</title>
     <script type="text/javascript">
+      const locationURL = new URL(window.location.href);
+      let urlAdjusted = false;
+      console.log(locationURL);
+      if (locationURL.pathname.endsWith('/')) {
+        locationURL.pathname = locationURL.pathname.substring(0, locationURL.pathname.length -1);
+        urlAdjusted = true;
+        console.log('here', locationURL);
+      }
+
+      if (locationURL.pathname.toLowerCase() !== locationURL.pathname) {
+        locationURL.pathname = locationURL.pathname.toLowerCase();
+        urlAdjusted = true;
+      }
+
+      if (urlAdjusted) {
+        window.location.href = locationURL.href;
+      }
+    </script>
+
+    <script type="text/javascript">
       window.isErrorPage = true;
       window.errorCode = '404';
     </script>


### PR DESCRIPTION
This PR reduces the need for need to create multiple redirect entries for URLs ending with `/` or having upper case characters.

**LIMITATION:** The feature only works if there is no actual page mapped to that URL, so Franklin serves the 404 page.

Example:
With only 1 redirect entry
<img width="1218" alt="Screenshot 2023-08-14 at 13 10 36" src="https://github.com/hlxsites/moleculardevices/assets/3651689/7d5e1fa1-168e-427a-b6cf-d91cb1db0b2b">

All of the following URLs will work:
https://handle-redirects--moleculardevices--hlxsites.hlx.page/test-redirects-case (via the xcel sheet)
https://handle-redirects--moleculardevices--hlxsites.hlx.page/test-redirects-case/
https://handle-redirects--moleculardevices--hlxsites.hlx.page/Test-Redirects-Case
https://handle-redirects--moleculardevices--hlxsites.hlx.page/Test-Redirects-Case/
https://handle-redirects--moleculardevices--hlxsites.hlx.page/TEST-REDIRECTS-CASE
https://handle-redirects--moleculardevices--hlxsites.hlx.page/TEST-REDIRECTS-CASE/

