### PR TITLE
Fix breadcrumbs for resource pages globally #1041

### DIFF
--- a/blocks/breadcrumbs/breadcrumbs-create.js
+++ b/blocks/breadcrumbs/breadcrumbs-create.js
@@ -120,10 +120,6 @@ const customBreadcrumbs = {
     name: 'Resources',
     url_path: '/search-results',
   },
-  'videos-and-webinars': {
-    name: 'Resources',
-    url_path: '/resources',
-  },
 };
 
 function getCustomUrl(path, part) {

--- a/blocks/breadcrumbs/breadcrumbs-create.js
+++ b/blocks/breadcrumbs/breadcrumbs-create.js
@@ -120,6 +120,10 @@ const customBreadcrumbs = {
     name: 'Resources',
     url_path: '/search-results',
   },
+  'videos-and-webinars': {
+    name: 'Resources',
+    url_path: '/resources',
+  },
 };
 
 function getCustomUrl(path, part) {

--- a/blocks/breadcrumbs/breadcrumbs-create.js
+++ b/blocks/breadcrumbs/breadcrumbs-create.js
@@ -178,7 +178,7 @@ export default async function createBreadcrumbs(container) {
       url_path: '/',
     },
   ];
-  if (includedResourceTypes.includes(pg.type)) {
+  if (pg && includedResourceTypes.includes(pg.type)) {
     breadcrumbs.push(
       {
         name: 'Resources',


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1041

Test URLs:
**Home > Resources for Cell Counter**
- Before: https://main--moleculardevices--hlxsites.hlx.page/applications/cell-counting/cell-counter-jurkat-cells
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/applications/cell-counting/cell-counter-jurkat-cells

**Home > Resources for Application Note**
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/app-note/br/spectral-fusion-illumination-technology-for-extended-dynamic-range-on-spectramax-i3x-reader
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/app-note/br/spectral-fusion-illumination-technology-for-extended-dynamic-range-on-spectramax-i3x-reader

**Home > Resources for Videos & Webinars**
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/dd/img/fast-and-simple-3d-spheroid-analysis-using-the-automated-high-content-imaging
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/dd/img/fast-and-simple-3d-spheroid-analysis-using-the-automated-high-content-imaging

- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/bpd/colony-picking-automation
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/bpd/colony-picking-automation

- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/dd/img/automation-high-content-imaging-for-organoid-research
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/dd/img/automation-high-content-imaging-for-organoid-research

**Home > Resources for Interactive Demo**
- Before: https://main--moleculardevices--hlxsites.hlx.page/resources/interactive-demo/cloneselect-imager-fl
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/resources/interactive-demo/cloneselect-imager-fl


- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/br/elisa-workflow
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/br/elisa-workflow

**Home > Resources > Customer Breakthrough > Title for Customer Breakthrough**
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/dd/img/qorium
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/customer-breakthrough/dd/img/qorium

**Other random pages for rechecking other breadcrumb behavior**

Brochure
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/brochures/dd/img/a-life-sciences-company
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/en/assets/brochures/dd/img/a-life-sciences-company

Lab Notes
- Before: https://main--moleculardevices--hlxsites.hlx.page/lab-notes/microplate-readers/gxp-regulated-industry-assessments-of-microplate-readers
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/lab-notes/microplate-readers/gxp-regulated-industry-assessments-of-microplate-readers

News
- Before:  https://main--moleculardevices--hlxsites.hlx.page/newsroom/news/molecular-devices-launches-custom-organoid-line-expansion-service-using-unique-bioprocess-technology-for-high-throughput-applications
- After:  https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/newsroom/news/molecular-devices-launches-custom-organoid-line-expansion-service-using-unique-bioprocess-technology-for-high-throughput-applications

Application
- Before: https://main--moleculardevices--hlxsites.hlx.page/applications/cell-counting
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/applications/cell-counting

Product
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-single-cell-printer-series
- After: https://1041-breadcrumb--moleculardevices--hlxsites.hlx.page/products/clone-screening/mammalian-screening/cloneselect-single-cell-printer-series
