### PR TITLE
Fix country selector to only use exact matches

### DIFF
--- a/blocks/local-distributor/local-distributor.js
+++ b/blocks/local-distributor/local-distributor.js
@@ -147,7 +147,7 @@ export default async function decorate(block) {
     }
 
     const filterdata = distributors
-      .filter(({ Country }) => Country.includes(countryName) > 0)
+      .filter(({ Country }) => Country === countryName)
       .filter(({ PrimaryProducts }) => PrimaryProducts.includes(productFamily) > 0);
 
     let finalHtml = '';


### PR DESCRIPTION
Partial fix for #1055

Test URLs:
Found country:
Before: https://main--moleculardevices--hlxsites.hlx.page/contact-search?country=United%20States&product_family=
After: https://issue-1055-country-selector--moleculardevices--hlxsites.hlx.page/contact-search?country=United%20States&product_family=

Not found country (with a name being a substring of a found one):
Before: https://main--moleculardevices--hlxsites.hlx.page/contact-search?country=Guinea&product_family=
After: https://issue-1055-country-selector--moleculardevices--hlxsites.hlx.page/contact-search?country=Guinea&product_family=
