### PR TITLE
fix: hubsport URL parameter handling

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -13,8 +13,10 @@ const getDefaultEmbed = (url) => {
 };
 
 const embedHubspot = (url) => {
+  // clean up hubspot url query paramaters
+  const urlStr = url.href.replaceAll('%20', ' ');
   const embedHTML = `<div style="left: 0; width: 100%; height: 166px; position: relative;">
-        <iframe src="${url.href}" 
+        <iframe src="${urlStr}" 
         style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
         frameborder="0" loading="lazy"></iframe>
       </div>`;


### PR DESCRIPTION
Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/br/exploring-the-absorbance-based-assay-applications-from-virus-to-cannabis-research
- After: https://hubspot-url--moleculardevices--hlxsites.hlx.page/en/assets/tutorials-videos/br/exploring-the-absorbance-based-assay-applications-from-virus-to-cannabis-research
