### PR TITLE
Open Schema and Hreflang tags missing for Main Pages #1127

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -581,7 +581,7 @@ function addPageSchema() {
       };
     }
 
-    if (type === 'Product' || type.includes('Category') || path === '/products') {
+    if (type === 'Product' || type.includes('Category')) {
       schemaInfo = {
         '@context': 'https://schema.org',
         '@graph': [
@@ -597,6 +597,26 @@ function addPageSchema() {
               url: schemaImageUrl,
             },
             brand,
+          },
+        ],
+      };
+    }
+
+    if (path === '/products') {
+      schemaInfo = {
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Product',
+            name: schemaTitle,
+            description: getMetadata('description'),
+            category: keywords,
+            url: document.querySelector("link[rel='canonical']").href,
+            image: {
+              '@type': 'ImageObject',
+              representativeOfPage: 'True',
+              url: schemaImageUrl,
+            },
           },
         ],
       };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -441,7 +441,10 @@ function addPageSchema() {
   const includedTypes = ['Product', 'Application', 'Category', 'homepage', 'Blog', 'Event', 'Application Note'];
   const type = getMetadata('template');
   const spTypes = (type) ? type.split(',').map((k) => k.trim()) : [];
-  if (!includedTypes.some((r) => spTypes.indexOf(r) !== -1)) {
+
+  const includedPaths = ['/products'];
+  const path = window.location.pathname;
+  if (!(includedTypes.some((r) => spTypes.indexOf(r) !== -1) || includedPaths.includes(path))) {
     return;
   }
 
@@ -578,7 +581,7 @@ function addPageSchema() {
       };
     }
 
-    if (type === 'Product' || type.includes('Category')) {
+    if (type === 'Product' || type.includes('Category') || path === '/products') {
       schemaInfo = {
         '@context': 'https://schema.org',
         '@graph': [

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -438,9 +438,10 @@ async function decorateTemplates(main) {
 function addPageSchema() {
   if (document.querySelector('head > script[type="application/ld+json"]')) return;
 
-  const type = getMetadata('template');
   const includedTypes = ['Product', 'Application', 'Category', 'homepage', 'Blog', 'Event', 'Application Note'];
-  if (!includedTypes.includes(type)) {
+  const type = getMetadata('template');
+  const spTypes = (type) ? type.split(',').map((k) => k.trim()) : [];
+  if (!includedTypes.some((r) => spTypes.indexOf(r) !== -1)) {
     return;
   }
 
@@ -685,11 +686,13 @@ function addPageSchema() {
 }
 
 function addHreflangTags() {
+  const includedTypes = ['homepage', 'Product', 'Application', 'Category', 'Technology', 'Customer Breakthrough', 'Video Gallery', 'contact', 'About Us'];
   const type = getMetadata('template');
-  const includedTypes = ['homepage', 'Product', 'Application', 'Technology', 'Customer Breakthrough', 'Video Gallery', 'contact', 'About Us'];
+  const spTypes = (type) ? type.split(',').map((k) => k.trim()) : [];
+
+  const includedPaths = ['/leadership', '/products', '/applications', '/customer-breakthroughs'];
   const path = window.location.pathname;
-  const includedPaths = ['/leadership'];
-  if (!(includedTypes.includes(type) || includedPaths.includes(path))) {
+  if ((!includedTypes.some((r) => spTypes.indexOf(r) !== -1) || includedPaths.includes(path))) {
     return;
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -686,6 +686,8 @@ function addPageSchema() {
 }
 
 function addHreflangTags() {
+  if (document.querySelectorAll('head link[hreflang]').length > 0) return;
+
   const includedTypes = ['homepage', 'Product', 'Application', 'Category', 'Technology', 'Customer Breakthrough', 'Video Gallery', 'contact', 'About Us'];
   const type = getMetadata('template');
   const spTypes = (type) ? type.split(',').map((k) => k.trim()) : [];

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -692,7 +692,7 @@ function addHreflangTags() {
 
   const includedPaths = ['/leadership', '/products', '/applications', '/customer-breakthroughs'];
   const path = window.location.pathname;
-  if ((!includedTypes.some((r) => spTypes.indexOf(r) !== -1) || includedPaths.includes(path))) {
+  if (!(includedTypes.some((r) => spTypes.indexOf(r) !== -1) || includedPaths.includes(path))) {
     return;
   }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1127

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://1127-schema--moleculardevices--hlxsites.hlx.page/

Products
https://1127-schema--moleculardevices--hlxsites.hlx.page/products

Customer Breakthroughs
https://1127-schema--moleculardevices--hlxsites.hlx.page/customer-breakthroughs
https://live-md30.pantheonsite.io/customer-breakthroughs has no schema

Video Gallery
https://1127-schema--moleculardevices--hlxsites.hlx.page/video-gallery
https://live-md30.pantheonsite.io//video-gallery has no schema

Technology
https://1127-schema--moleculardevices--hlxsites.hlx.page/technology
https://live-md30.pantheonsite.io/technology has no schema

Applications
https://1127-schema--moleculardevices--hlxsites.hlx.page/applications
https://live-md30.pantheonsite.io/applications has no schema

Other main pages
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/3d-biology
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/microplate-readers
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/clone-screening
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/axon-patch-clamp-system
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/additional-products
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/assay-kits
https://1127-schema--moleculardevices--hlxsites.hlx.page/products/accessories-consumables
