### PR TITLE
fix: video links should not only be wrapped in paragraph

### DIFF
--- a/blocks/resources/resources.css
+++ b/blocks/resources/resources.css
@@ -65,6 +65,10 @@ main .section .resources-wrapper {
   height: 309px;
 }
 
+.resources .vidyard-player-container img {
+  height: 309px;
+}
+
 .resources .vidyard-video-placeholder {
   position: relative;
   width: 100%;
@@ -198,7 +202,7 @@ main .section .resources-wrapper {
 }
 
 @media only screen and (max-width: 1199px) {
-  .resources .video-container {
+  .resources .video-container, .resources .vidyard-player-container img {
     height: 253px;
   }
 }
@@ -213,7 +217,7 @@ main .section .resources-wrapper {
     max-width: 100%;
   }
 
-  .resources .video-container {
+  .resources .video-container, .resources .vidyard-player-container img {
     height: auto;
   }
 

--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -164,7 +164,7 @@ export default async function decorate(block) {
         const videoFragmentHtml = await fetchFragment(item.path);
         const videoFragment = document.createElement('div');
         videoFragment.innerHTML = videoFragmentHtml;
-        const videoElement = videoFragment.querySelector('p a[href^="https://share.vidyard.com/watch/"]');
+        const videoElement = videoFragment.querySelector('a[href^="https://share.vidyard.com/watch/"]');
         const videoHref = videoElement?.href;
         if (videoElement && videoHref && videoHref.startsWith('https://')) {
           const videoURL = new URL(videoHref);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1135 

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal#resources
- After: https://video-link--moleculardevices--hlxsites.hlx.live/products/cellular-imaging-systems/high-content-imaging/imagexpress-micro-confocal#resources
