### PR TITLE
Fix arrow icons in contact-search when changing countries

### DIFF
--- a/blocks/local-distributor/local-distributor.js
+++ b/blocks/local-distributor/local-distributor.js
@@ -228,6 +228,7 @@ export default async function decorate(block) {
   searchButton.addEventListener('click', () => {
     // eslint-disable-next-line no-unused-expressions
     window.location.pathname === '/contact' ? redirectToContactSearch() : renderAddress();
+    decorateIcons(block);
   });
 
   hideResult();


### PR DESCRIPTION
The problem here is that:

- When we first access the page, the form defaults to USA, and the icons are showing
- However, when the form is changed, and a new country, such as Albania, is selected, the icons disappear

Fix #1123

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://1123-fix-icons-contact-search--moleculardevices--hlxsites.hlx.page/contact-search
