### PR TITLE
Implement sticky headers for specifications

### DIFF
--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -4,13 +4,19 @@ main .section .specifications-wrapper {
 }
 
 .specifications .table-container {
-  overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
 .specifications .table-container::-webkit-scrollbar {
   display: none;
+}
+
+.specifications thead th {
+  top: var(--stacked-height);
+  position: sticky;
+  z-index: 3;
+  background-color: white;
 }
 
 .specifications .responsive-table {
@@ -42,7 +48,7 @@ main .section .specifications-wrapper {
 
 .specifications .responsive-table th {
   text-align: left;
-  padding: 15px;
+  padding: 0;
   font-weight: 100;
 }
 
@@ -66,10 +72,7 @@ main .section .specifications-wrapper {
 
 .specifications .responsive-table th:first-child,
 .specifications .responsive-table td:first-child {
-  position: sticky;
-  left: 0;
   background-color: var(--background-color);
-  z-index: 1;
   width: 380px;
 }
 

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -88,8 +88,7 @@ export default async function decorate(block) {
     });
   });
 
-  const tHeadBlock = domEl('thead', { class: 'table-head' }, headRow,
-  );
+  const tHeadBlock = domEl('thead', headRow);
   block.append(div({ class: 'table-container' },
     domEl('table', { class: 'responsive-table' }, tHeadBlock, tBodyBlock),
   ));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -40,6 +40,7 @@ const LCP_BLOCKS = ['hero', 'hero-advanced', 'featured-highlights']; // add your
 window.hlx.RUM_GENERATION = 'molecular-devices'; // add your RUM generation information here
 
 let LAST_SCROLL_POSITION = 0;
+let LAST_STACKED_HEIGHT = 0;
 let STICKY_ELEMENTS;
 let PREV_STICKY_ELEMENTS;
 const mobileDevice = window.matchMedia('(max-width: 991px)');
@@ -924,6 +925,10 @@ function enableStickyElements() {
     });
 
     LAST_SCROLL_POSITION = currentScrollPosition;
+    if (stackedHeight !== LAST_STACKED_HEIGHT) {
+      LAST_STACKED_HEIGHT = stackedHeight;
+      document.querySelector(':root').style.setProperty('--stacked-height', `${stackedHeight}px`);
+    }
   });
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -57,6 +57,8 @@
 /* stylelint-enable */
 
 :root {
+  --stacked-height: 0;
+
   /* colors */
   --text-color: #34393d;
   --text-blue: #008da9;


### PR DESCRIPTION
Fix #434

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options
- After: https://issue-434--moleculardevices--hlxsites.hlx.page/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options

