### PR TITLE
Issue 434 - Implement sticky headers for specifications table

### DIFF
--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -22,7 +22,7 @@ main .section .specifications-wrapper {
 .specifications thead th {
   top: var(--stacked-height);
   position: sticky;
-  z-index: 20;
+  z-index: 1;
   background-color: white;
 }
 
@@ -55,15 +55,9 @@ main .section .specifications-wrapper {
 
 .specifications .responsive-table th {
   text-align: left;
-  padding: 0 5px;
+  padding: 15px 15px 0;
   font-weight: 100;
 }
-
-/* Table with only one product */
-.specifications .responsive-table th:last-child:nth-child(2) {
-  padding: 0;
-}
-
 
 .specifications .responsive-table td {
   padding: 15px;
@@ -88,8 +82,21 @@ main .section .specifications-wrapper {
   position: sticky;
   left: 0;
   background-color: var(--background-color);
-  z-index: 4;
+  z-index: 1;
   width: 380px;
+}
+
+.specifications .table-container.multiple-products thead th {
+  z-index: 0;
+}
+
+/* Table with only one product */
+.specifications .responsive-table th:last-child:nth-child(2) {
+  padding: 0;
+}
+
+.specifications .multiple-products .responsive-table th:first-child {
+  z-index: 1;
 }
 
 .section[aria-labelledby="specifications-options"] .default-content-wrapper:last-child .download-button {

--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -3,14 +3,14 @@ main .section .specifications-wrapper {
   margin-bottom: 50px;
 }
 
-.specifications .table-container {
+.specifications .table-container.multiple-products {
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
 
-@media only screen and (min-width: 767px) {
-  .specifications .table-container {
+@media only screen and (min-width: 991px) {
+  .specifications .table-container.multiple-products {
     overflow-x: visible;
   }
 }

--- a/blocks/specifications/specifications.css
+++ b/blocks/specifications/specifications.css
@@ -9,8 +9,21 @@ main .section .specifications-wrapper {
   scrollbar-width: none;
 }
 
+@media only screen and (min-width: 767px) {
+  .specifications .table-container {
+    overflow-x: visible;
+  }
+}
+
 .specifications .table-container::-webkit-scrollbar {
   display: none;
+}
+
+.specifications thead th {
+  top: var(--stacked-height);
+  position: sticky;
+  z-index: 20;
+  background-color: white;
 }
 
 .specifications .responsive-table {
@@ -42,9 +55,15 @@ main .section .specifications-wrapper {
 
 .specifications .responsive-table th {
   text-align: left;
-  padding: 15px;
+  padding: 0 5px;
   font-weight: 100;
 }
+
+/* Table with only one product */
+.specifications .responsive-table th:last-child:nth-child(2) {
+  padding: 0;
+}
+
 
 .specifications .responsive-table td {
   padding: 15px;
@@ -69,7 +88,7 @@ main .section .specifications-wrapper {
   position: sticky;
   left: 0;
   background-color: var(--background-color);
-  z-index: 1;
+  z-index: 4;
   width: 380px;
 }
 

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -88,8 +88,7 @@ export default async function decorate(block) {
     });
   });
 
-  const tHeadBlock = domEl('thead', { class: 'table-head' }, headRow,
-  );
+  const tHeadBlock = domEl('thead', headRow);
   block.append(div({ class: 'table-container' },
     domEl('table', { class: 'responsive-table' }, tHeadBlock, tBodyBlock),
   ));

--- a/blocks/specifications/specifications.js
+++ b/blocks/specifications/specifications.js
@@ -89,7 +89,11 @@ export default async function decorate(block) {
   });
 
   const tHeadBlock = domEl('thead', headRow);
-  block.append(div({ class: 'table-container' },
+  const tableContainerClasses = ['table-container'];
+  if (specData.product?.data?.length > 1) {
+    tableContainerClasses.push('multiple-products');
+  }
+  block.append(div({ class: tableContainerClasses },
     domEl('table', { class: 'responsive-table' }, tHeadBlock, tBodyBlock),
   ));
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -40,6 +40,7 @@ const LCP_BLOCKS = ['hero', 'hero-advanced', 'featured-highlights']; // add your
 window.hlx.RUM_GENERATION = 'molecular-devices'; // add your RUM generation information here
 
 let LAST_SCROLL_POSITION = 0;
+let LAST_STACKED_HEIGHT = 0;
 let STICKY_ELEMENTS;
 let PREV_STICKY_ELEMENTS;
 const mobileDevice = window.matchMedia('(max-width: 991px)');
@@ -924,6 +925,10 @@ function enableStickyElements() {
     });
 
     LAST_SCROLL_POSITION = currentScrollPosition;
+    if (stackedHeight !== LAST_STACKED_HEIGHT) {
+      LAST_STACKED_HEIGHT = stackedHeight;
+      document.querySelector(':root').style.setProperty('--stacked-height', `${stackedHeight}px`);
+    }
   });
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -57,6 +57,8 @@
 /* stylelint-enable */
 
 :root {
+  --stacked-height: 0;
+
   /* colors */
   --text-color: #34393d;
   --text-blue: #008da9;


### PR DESCRIPTION
Fix #434

Test URLs:
Single-product:
Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options
After: https://issue-434--moleculardevices--hlxsites.hlx.page/products/microplate-readers/absorbance-readers/spectramax-quickdrop-micro-volume-spectrophotometer#specifications-options

Multiproduct:
Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers#specifications-options
After: https://issue-434--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-m-series-readers#specifications-options

Notes: sticky headers are not implemented for multiproduct tables in mobile. If it's very important we can always open an issue in the future, but it will require more js (as css prevents sticky headers from working if we set overflow-x in the table)