### PR TITLE
Use original title for breadcrumbs instead of decorated one

### DIFF
--- a/blocks/breadcrumbs/breadcrumbs-create.js
+++ b/blocks/breadcrumbs/breadcrumbs-create.js
@@ -153,7 +153,7 @@ function getName(pageIndex, path, part, current) {
   }
 
   if (current) {
-    return document.title;
+    return document.originalTitle ? document.originalTitle : document.title;
   }
 
   return part;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -778,6 +778,7 @@ async function loadEager(doc) {
   document.documentElement.setAttribute('original-lang', document.documentElement.lang);
 
   if (!isHomepage()) {
+    document.originalTitle = document.title;
     document.title = `${document.title ?? ''} | Molecular Devices`;
   }
   decorateTemplateAndTheme();


### PR DESCRIPTION
Test URLs:
Before: https://main--moleculardevices--hlxsites.hlx.page/test_404_page
After: https://fix-error-page-title--moleculardevices--hlxsites.hlx.page/test_404_page

Product page (should behave the same)
Before: https://main--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-i3x-readers
After: https://fix-error-page-title--moleculardevices--hlxsites.hlx.page/products/microplate-readers/multi-mode-readers/spectramax-i3x-readers
