### PR TITLE
 Fix anchor link #1178

### DIFF
--- a/blocks/page-tabs/page-tabs.js
+++ b/blocks/page-tabs/page-tabs.js
@@ -80,8 +80,9 @@ export default async function decorate(block) {
     if (!activeHash) return;
 
     const element = document.getElementById(activeHash);
-    if (element) {
-      const targetTabName = element.closest('.tabs')?.getAttribute('aria-labelledby');
+    const tab = element?.closest('.tabs');
+    if (tab) {
+      const targetTabName = tab.getAttribute('aria-labelledby');
       const targetTab = block.querySelector(`a[href="#${targetTabName}"]`);
       if (!targetTab) return;
       openTab(targetTab);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1178

Test URLs:

**Link with anchor**
Before: https://main--moleculardevices--hlxsites.hlx.page/about-us#who-we-are
After: https://1178-anchor--moleculardevices--hlxsites.hlx.page/about-us#who-we-are

**View Modules links to the applications tab**
Before: https://main--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/acquisition-and-analysis-software/metaxpress
After: https://1178-anchor--moleculardevices--hlxsites.hlx.page/products/cellular-imaging-systems/acquisition-and-analysis-software/metaxpress

**Link with anchor to a title in a tab:**
Before: https://main--moleculardevices--hlxsites.hlx.page/about-us#we-design-complete-solutions-for-any-application-to-meet-customer-needs-today--and-tomorrow
After: https://1178-anchor--moleculardevices--hlxsites.hlx.page/about-us#we-design-complete-solutions-for-any-application-to-meet-customer-needs-today--and-tomorrow

**Link with anchor that is nonexistent:**
Before: https://main--moleculardevices--hlxsites.hlx.page/about-us#nonexistent-id
After: https://1178-anchor--moleculardevices--hlxsites.hlx.page/about-us#nonexistent-id

