### PR TITLE
fix: order options for hero

### DIFF
--- a/blocks/ordering-options/ordering-options.js
+++ b/blocks/ordering-options/ordering-options.js
@@ -418,7 +418,8 @@ async function renderOptions(orderBlock, heroBlock, productRefs, itemDescription
 
 function showHideStoreFeature(showStore, orderBlock, heroBlock) {
   renderCartWidget(showStore);
-  const heroOrder = heroBlock.querySelector('.order-container');
+  let heroOrder = heroBlock?.querySelector('.order-container');
+  if (heroOrder && heroBlock.querySelector('img')) heroOrder = undefined;
   if (showStore) {
     orderBlock.classList.remove(STORE_HIDDEN_CLASS);
     if (heroOrder) heroOrder.classList.remove(STORE_HIDDEN_CLASS);
@@ -462,6 +463,6 @@ export default async function decorate(block) {
   showHideStoreFeature(showStore, block, heroBlock);
 
   document.addEventListener('geolocationUpdated', () => {
-    showHideStoreFeature(block, showStore);
+    showHideStoreFeature(showStore, block, heroBlock);
   });
 }

--- a/blocks/ordering-options/ordering-options.js
+++ b/blocks/ordering-options/ordering-options.js
@@ -422,12 +422,14 @@ function showHideStoreFeature(showStore, orderBlock, heroBlock) {
   if (heroOrder && heroBlock.querySelector('img')) heroOrder = undefined;
   if (showStore) {
     orderBlock.classList.remove(STORE_HIDDEN_CLASS);
-    if (heroOrder) heroOrder.classList.remove(STORE_HIDDEN_CLASS);
-    // hide buttons in hero and instead show option form
-    if (heroBlock) {
-      heroBlock.querySelectorAll('.button-container').forEach((buttonContainer) => {
-        buttonContainer.remove();
-      });
+    if (heroOrder) {
+      heroOrder.classList.remove(STORE_HIDDEN_CLASS);
+      // hide buttons in hero and instead show option form
+      if (heroBlock) {
+        heroBlock.querySelectorAll('.button-container').forEach((buttonContainer) => {
+          buttonContainer.remove();
+        });
+      }
     }
   } else {
     orderBlock.classList.add(STORE_HIDDEN_CLASS);


### PR DESCRIPTION
Fix #1259

Display rule for order options in hero banner:
- Hero Banner no bg image > show order options in hero area
- Hero Banner with bg image > no order options in hero area
- Hero Advanced Banner > no order options in hero area

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.live/
- After: https://add2cart-fix--moleculardevices--hlxsites.hlx.live/products/assay-kits/igg-quantification-assays/valitatiter#ordering-options
- After 2: https://add2cart-fix--moleculardevices--hlxsites.hlx.live/products/culture-media-reagents/clonematrix#ordering-options
- After 3: https://add2cart-fix--moleculardevices--hlxsites.hlx.live/products/assay-kits/gpcrs/fura-2-qbt-calcium-kit

