### PR TITLE
fix: use displayType for card render

### DIFF
--- a/blocks/card/card.js
+++ b/blocks/card/card.js
@@ -151,7 +151,7 @@ class Card {
         ) : '',
         item.badgeText ? div({ class: 'badge' }, item.badgeText) : '',
         div({ class: 'card-caption' },
-          item.type ? div({ class: 'card-type' }, item.type) : '',
+          item.displayType ? div({ class: 'card-type' }, item.displayType) : '',
           h3(
             this.titleLink ? a({ href: cardLink }, cardTitle) : cardTitle,
           ),


### PR DESCRIPTION
This can only be tested on the translated URLs once merged

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/applications/plasmid/aav-plasmids
- After: https://fix-cards--moleculardevices--hlxsites.hlx.page/applications/plasmid/aav-plasmids
