### PR TITLE
dreamdata code added after drift code 

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -25,6 +25,15 @@ function LoadDriftWidget() {
     }
     drift.SNIPPET_VERSION = '0.3.1';
     drift.load('pyupvvckemp9');
+    // dreamdata script
+    drift.on("emailCapture", function(payload) {
+  if (payload.data && payload.data.email && window.analytics) {
+      window.analytics.identify(null, {
+          email: payload.data.email,
+      });
+      window.analytics.track("chat_converted");
+  }
+});
 };
 /* eslint-enable */
 


### PR DESCRIPTION
We are onboarindg a new multi-touch attribution tool called Dreamdata. We are integrating several of our sources to the tool. 
It will  identify users when an email is captured as part of a campaign. Below is a snippet we can use to ensure the user is identified within Dreamdata.


drift.on("emailCapture", function(payload) {
  if (payload.data && payload.data.email && window.analytics) {
      window.analytics.identify(null, {
          email: payload.data.email,
      });
      window.analytics.track("chat_converted");
  }
});



Note: The script has to be loaded after your Drift script. Example you could paste in the script as is just after your Drift script in your header. Which will identify users automatically and throw an chat_converted event.

Copy and Paste it immediately after the  tag on each page of your site.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/
- After: https://dreamdata-code--moleculardevices--hlxsites.hlx.page/
