### PR TITLE
remove en from hreflang sitemap as added in default

### DIFF
--- a/tools/sitemap/create.js
+++ b/tools/sitemap/create.js
@@ -12,7 +12,6 @@ const hreflangMap = [
   ['es', { baseUrl: 'https://es.moleculardevices.com' }],
   ['fr', { baseUrl: 'https://fr.moleculardevices.com' }],
   ['ko', { baseUrl: 'https://ko.moleculardevices.com' }],
-  ['en', { baseUrl: 'https://www.moleculardevices.com' }],
   ['zh', { baseUrl: 'https://www.moleculardevices.com.cn' }],
   ['x-default', { baseUrl: 'https://www.moleculardevices.com' }],
 ];


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.hlx.page/content-sitemap.xml
- After: https://sitemap-changes--moleculardevices--hlxsites.hlx.page/content-sitemap.xml
