### PR TITLE
removes cta from chart your own course pages

### DIFF
--- a/campaigns/en/chart-your-own-course-ppc.html
+++ b/campaigns/en/chart-your-own-course-ppc.html
@@ -69,10 +69,10 @@
               Molecular Devices
             </a>
           </div>
-          <div class="buttons-container">
+          <!-- <div class="buttons-container">
             <a href="https://www.moleculardevices.com/quote-request?pid=microplate-readers&cmp=701Rn00000OwhGZIAZ" target="_blank"
               title="Get more information" class="quote-button" rel="noopener noreferrer">Get more information</a>
-          </div>
+          </div> -->
         </nav>
       </div>
     </header>

--- a/campaigns/en/chart-your-own-course.html
+++ b/campaigns/en/chart-your-own-course.html
@@ -67,11 +67,11 @@
               Molecular Devices
             </a>
           </div>
-          <div class="buttons-container">
+          <!-- <div class="buttons-container">
             <a href="https://www.moleculardevices.com/quote-request?pid=microplate-readers" target="_blank"
               title="Request Pricing Information" class="quote-button" rel="noopener noreferrer">Request Pricing
               Information</a>
-          </div>
+          </div> -->
         </nav>
       </div>
     </header>


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.aem.page/campaigns/en/chart-your-own-course-ppc.html
- After: https://update-html-2--moleculardevices--hlxsites.aem.page/campaigns/en/chart-your-own-course-ppc.html
