### PR TITLE
updated fragment carousel on slas 2025 page

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -194,6 +194,7 @@ main .global-carousel.title-center h2 {
   text-align: center;
 }
 
+main .section.global-carousel .carousel h2:only-child,
 main .section.global-carousel .carousel h2 + h3 {
   margin-bottom: 48px;
 }

--- a/blocks/fragments-carousel/fragments-carousel.css
+++ b/blocks/fragments-carousel/fragments-carousel.css
@@ -16,6 +16,11 @@ main .fragments-carousel-wrapper .carousel-nav-button {
   border-color: var(--text-color);
 }
 
+main .layout-60-40 .carousel.fragments-carousel .columns > div:not(> div:only-child) {
+  display: grid;
+  grid-template-columns: 60% 40%;
+}
+
 @media only screen and (max-width: 767px) {
   main .fragments-carousel .carousel-item-text .button-container {
     margin-bottom: 2rem;

--- a/fragments/service-support/lab-automation-solutions-workflow.html
+++ b/fragments/service-support/lab-automation-solutions-workflow.html
@@ -306,7 +306,7 @@
         loading="lazy"
       />
       <br>
-      <div class="read-comp-btn-part text-center"><p class="button-container"><strong><a href="/quote-request?request_type=Call&pid=laboratory-automation-customization-solutions" title="Speak to a specialist" class="button primary">Speak to a specialist<span class="button-border"></span></a></strong></p></div>
+      <div class="read-comp-btn-part text-center"><p class="button-container"><strong><a href="/quote-request?pid=laboratory-automation-customization-solutions&cmp=701Rn00000aQiNLIA0" title="Speak to a specialist" class="button primary">Speak to a specialist<span class="button-border"></span></a></strong></p></div>
     </div>
   </div>
   <div class="lab-robot-container hide-mob">
@@ -324,7 +324,7 @@
         loading="lazy"
       />
     </div>
-    <div class="read-comp-btn-part text-center"><p class="button-container"><strong><a href="/quote-request?pid=laboratory-automation-customization-solutions" title="Speak to a specialist" class="button primary">Speak to a specialist<span class="button-border"></span></a></strong></p></div>
+    <div class="read-comp-btn-part text-center"><p class="button-container"><strong><a href="/quote-request?pid=laboratory-automation-customization-solutions&cmp=701Rn00000aQiNLIA0" title="Speak to a specialist" class="button primary">Speak to a specialist<span class="button-border"></span></a></strong></p></div>
   </div>
   <div class="cm-infographic-img hide-mob">
     <a class="cm-info-link" href="/service-support/lab-automation-solutions/lab-automation-for-high-content-screening" data-responsive-image-style="applications_mm_covid_19_webp" title="Lab Components" data-di-id="di-id-206b6724-4c855d88">


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--moleculardevices--hlxsites.aem.page/en/assets/promotion/dd/img/slas-europe-2025
- After: https://slas-2025--moleculardevices--hlxsites.aem.page/en/assets/promotion/dd/img/slas-europe-2025
